### PR TITLE
feat: enable-npr-fourquark option added to configure

### DIFF
--- a/Hadrons/Modules/MNPR/FourQuarkFullyConnected.cpp
+++ b/Hadrons/Modules/MNPR/FourQuarkFullyConnected.cpp
@@ -1,7 +1,12 @@
+#ifdef NPR_FOURQUARK
+
 #include <Hadrons/Modules/MNPR/FourQuarkFullyConnected.hpp>
 
 using namespace Grid;
 using namespace Hadrons;
 using namespace MNPR;
 
+
 template class Grid::Hadrons::MNPR::TFourQuarkFullyConnected<FIMPL>;
+
+#endif

--- a/Hadrons/Modules/MNPR/FourQuarkFullyConnected.cpp
+++ b/Hadrons/Modules/MNPR/FourQuarkFullyConnected.cpp
@@ -1,4 +1,4 @@
-#ifdef NPR_FOURQUARK
+#ifdef Hadrons_NPR_FOURQUARK
 
 #include <Hadrons/Modules/MNPR/FourQuarkFullyConnected.hpp>
 

--- a/Hadrons/Modules/MNPR/FourQuarkFullyConnected.hpp
+++ b/Hadrons/Modules/MNPR/FourQuarkFullyConnected.hpp
@@ -29,7 +29,7 @@
 
 /*  END LEGAL */
 
-#ifdef NPR_FOURQUARK
+#ifdef Hadrons_NPR_FOURQUARK
 
 #ifndef Hadrons_MNPR_FourQuarkFullyConnected_hpp_
 #define Hadrons_MNPR_FourQuarkFullyConnected_hpp_

--- a/Hadrons/Modules/MNPR/FourQuarkFullyConnected.hpp
+++ b/Hadrons/Modules/MNPR/FourQuarkFullyConnected.hpp
@@ -29,6 +29,8 @@
 
 /*  END LEGAL */
 
+#ifdef NPR_FOURQUARK
+
 #ifndef Hadrons_MNPR_FourQuarkFullyConnected_hpp_
 #define Hadrons_MNPR_FourQuarkFullyConnected_hpp_
 
@@ -250,5 +252,7 @@ void TFourQuarkFullyConnected<FImpl>::execute()
 END_MODULE_NAMESPACE
 
 END_HADRONS_NAMESPACE
+
+#endif
 
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ AC_ARG_WITH([grid],
 
 AC_ARG_ENABLE([npr-fourquark],
     [AC_HELP_STRING([--enable-npr-fourquark],[enable npr fourquark module])],
-    [AC_DEFINE([NPR_FOURQUARK],[1],[enable npr fourquark module])],[])
+    [AC_DEFINE([Hadrons_NPR_FOURQUARK],[1],[enable npr fourquark module])],[])
 
 AC_CHECK_PROG([GRIDCONF],[grid-config],[yes])
 if test x"$GRIDCONF" != x"yes" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,10 @@ AC_ARG_WITH([grid],
     [CXXFLAGS="$CXXFLAGS -I$with_grid/include"]
     [LDFLAGS="$LDFLAGS -L$with_grid/lib"])
 
+AC_ARG_ENABLE([npr-fourquark],
+    [AC_HELP_STRING([--enable-npr-fourquark],[enable npr fourquark module])],
+    [AC_DEFINE([NPR_FOURQUARK],[1],[enable npr fourquark module])],[])
+
 AC_CHECK_PROG([GRIDCONF],[grid-config],[yes])
 if test x"$GRIDCONF" != x"yes" ; then
     AC_MSG_ERROR([grid-config not found])


### PR DESCRIPTION
This is a first try at the `--enable-npr-fourquark` option Antonin requested. I did not test the compile guard properly.