### PR TITLE
Random point sources

### DIFF
--- a/Hadrons/Modules/MSource/RandomPoint.cpp
+++ b/Hadrons/Modules/MSource/RandomPoint.cpp
@@ -1,5 +1,5 @@
 /*
- * VectorPackRef.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ * RandomPoint.cpp, part of Hadrons (https://github.com/aportelli/Hadrons)
  *
  * Copyright (C) 2015 - 2023
  *
@@ -23,12 +23,12 @@
  */
 
 /*  END LEGAL */
-#include <Hadrons/Modules/MUtilities/VectorPackRef.hpp>
+#include <Hadrons/Modules/MSource/RandomPoint.hpp>
 
 using namespace Grid;
 using namespace Hadrons;
-using namespace MUtilities;
+using namespace MSource;
 
-template class HADRONS_NAMESPACE::MUtilities::TVectorPackRef<FIMPL::PropagatorField>;
-template class HADRONS_NAMESPACE::MUtilities::TVectorPackRef<std::vector<int>>;
-template class HADRONS_NAMESPACE::MUtilities::TVectorPackRef<std::string>;
+template class HADRONS_NAMESPACE::MSource::TRandomPoint<FIMPL>;
+template class HADRONS_NAMESPACE::MSource::TRandomPoint<ScalarImplCR>;
+

--- a/Hadrons/Modules/MSource/RandomPoint.cpp
+++ b/Hadrons/Modules/MSource/RandomPoint.cpp
@@ -4,6 +4,7 @@
  * Copyright (C) 2015 - 2023
  *
  * Author: Antonin Portelli <antonin.portelli@me.com>
+ * Author: Raoul Hodgson <raoul.hodgson@desy.de>
  *
  * Hadrons is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Hadrons/Modules/MSource/RandomPoint.hpp
+++ b/Hadrons/Modules/MSource/RandomPoint.hpp
@@ -1,0 +1,173 @@
+/*
+ * RandomPoint.hpp, part of Hadrons (https://github.com/aportelli/Hadrons)
+ *
+ * Copyright (C) 2015 - 2023
+ *
+ * Author: Antonin Portelli <antonin.portelli@me.com>
+ * Author: Lanny91 <andrew.lawson@gmail.com>
+ * Author: Peter Boyle <paboyle@ph.ed.ac.uk>
+ *
+ * Hadrons is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Hadrons is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Hadrons.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See the full license in the file "LICENSE" in the top level distribution 
+ * directory.
+ */
+
+/*  END LEGAL */
+
+#ifndef Hadrons_MSource_RandomPoint_hpp_
+#define Hadrons_MSource_RandomPoint_hpp_
+
+#include <Hadrons/Global.hpp>
+#include <Hadrons/Module.hpp>
+#include <Hadrons/ModuleFactory.hpp>
+
+BEGIN_HADRONS_NAMESPACE
+
+/*
+ 
+ RandomPoint source
+ ------------
+ * src_x = delta_x,position
+ 
+ * options:
+ - position: space-separated integer sequence (e.g. "0 1 1 0")
+ 
+ */
+
+/******************************************************************************
+ *                                  TRandomPoint                                     *
+ ******************************************************************************/
+BEGIN_MODULE_NAMESPACE(MSource)
+
+class RandomPointPar: Serializable
+{
+public:
+    GRID_SERIALIZABLE_CLASS_MEMBERS(RandomPointPar,
+                                    std::string, position);
+};
+
+template <typename FImpl>
+class TRandomPoint: public Module<RandomPointPar>
+{
+public:
+    BASIC_TYPE_ALIASES(FImpl,);
+public:
+    // constructor
+    TRandomPoint(const std::string name);
+    // destructor
+    virtual ~TRandomPoint(void) {};
+    // dependency relation
+    virtual std::vector<std::string> getInput(void);
+    virtual std::vector<std::string> getOutput(void);
+protected:
+    // setup
+    virtual void setup(void);
+    // execution
+    virtual void execute(void);
+};
+
+MODULE_REGISTER_TMP(RandomPoint,       TRandomPoint<FIMPL>,        MSource);
+MODULE_REGISTER_TMP(ScalarRandomPoint, TRandomPoint<ScalarImplCR>, MSource);
+
+/******************************************************************************
+ *                       TRandomPoint template implementation                       *
+ ******************************************************************************/
+// constructor /////////////////////////////////////////////////////////////////
+template <typename FImpl>
+TRandomPoint<FImpl>::TRandomPoint(const std::string name)
+: Module<RandomPointPar>(name)
+{}
+
+// dependencies/products ///////////////////////////////////////////////////////
+template <typename FImpl>
+std::vector<std::string> TRandomPoint<FImpl>::getInput(void)
+{
+    std::vector<std::string> in;
+    
+    return in;
+}
+
+template <typename FImpl>
+std::vector<std::string> TRandomPoint<FImpl>::getOutput(void)
+{
+    std::vector<std::string> out = {getName(),getName()+"_pos",getName()+"_str"};
+    
+    return out;
+}
+
+// setup ///////////////////////////////////////////////////////////////////////
+template <typename FImpl>
+void TRandomPoint<FImpl>::setup(void)
+{
+    envCreateLat(PropagatorField , getName());
+    envCreate(std::vector<int>, getName()+"_pos", 1, 0);
+    envCreate(std::string     , getName()+"_str", 1, "");
+}
+
+// execution ///////////////////////////////////////////////////////////////////
+template <typename FImpl>
+void TRandomPoint<FImpl>::execute(void)
+{
+    auto tmp = strToVec<std::string>(par().position);
+    int Nd = tmp.size();
+
+    if (Nd != env().getNd())
+    {
+        HADRONS_ERROR(Size, "position has " + std::to_string(Nd)
+                      + " components (must have " + std::to_string(env().getNd()) + ")");
+    }
+
+    auto& rng = rngSerial();
+
+    auto &position = envGet(std::vector<int>, getName()+"_pos");
+    position.resize(Nd);
+    for (int d=0; d<Nd; d++)
+    {
+        if (tmp[d] == "*") 
+        {
+            int NL = env().getDim(d);
+            auto dist = std::uniform_int_distribution<uint32_t>(0,NL-1);
+            fillScalar(position[d], dist, rng._generators[0]);
+        } 
+        else 
+        {
+            position[d] = stoi(tmp[d]);
+        }
+    }
+
+    auto &str = envGet(std::string, getName()+"_str");
+    str = "";
+    for (int d=0; d<Nd; d++)
+    {
+        str += std::to_string(position[d]);
+        if (d != Nd-1)
+            str += " ";
+    }
+
+    LOG(Message) << "Creating random point source at position " << position << std::endl;
+
+    auto             &src     = envGet(PropagatorField, getName());
+    SitePropagator   id;
+    
+    id  = 1.;
+    src = Zero();
+    pokeSite(id, src, position);
+}
+
+END_MODULE_NAMESPACE
+
+END_HADRONS_NAMESPACE
+
+#endif // Hadrons_MSource_RandomPoint_hpp_

--- a/Hadrons/Modules/MSource/RandomPoint.hpp
+++ b/Hadrons/Modules/MSource/RandomPoint.hpp
@@ -4,8 +4,7 @@
  * Copyright (C) 2015 - 2023
  *
  * Author: Antonin Portelli <antonin.portelli@me.com>
- * Author: Lanny91 <andrew.lawson@gmail.com>
- * Author: Peter Boyle <paboyle@ph.ed.ac.uk>
+ * Author: Raoul Hodgson <raoul.hodgson@desy.de>
  *
  * Hadrons is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/Hadrons/Modules/MUtilities/VectorPackRef.hpp
+++ b/Hadrons/Modules/MUtilities/VectorPackRef.hpp
@@ -63,6 +63,8 @@ public:
 };
 
 MODULE_REGISTER_TMP(PropagatorVectorPackRef, TVectorPackRef<FIMPL::PropagatorField>, MUtilities);
+MODULE_REGISTER_TMP(CoordinateVectorPackRef, TVectorPackRef<std::vector<int>>      , MUtilities);
+MODULE_REGISTER_TMP(StringVectorPackRef    , TVectorPackRef<std::string>           , MUtilities);
 
 /******************************************************************************
  *                 TVectorPackRef implementation                             *


### PR DESCRIPTION
Added a module to create random point sources with some coordinates fixed.
Uses a wildcard-like syntax. Still need to document this at some point.
e.g. for a random 3 position at time 7 is `<position>* * * 7</position>`.

Also added extra registrations for the `VectorPackRef` module to hold `string` or `vector<int>`.
Either could be used for the input to diagrams A and B, but I would recommend we use `vector<int>`