### PR TITLE
Feature/dmixing matteo

### DIFF
--- a/Hadrons/Modules/MContraction/DMixingTopA.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopA.hpp
@@ -111,9 +111,7 @@ public:
     // execution
     virtual void execute(void);
     // bespoke subcontractions
-    virtual SlicedPropagator contractA_half_l(const PropagatorField &GcuG, const std::vector<Coordinate *> &xs);
-    virtual std::vector<SlicedPropagator> contractA_half_r(const PropagatorField &GcuG, const std::vector<PropagatorField *> &ds_prop_pt);
-    virtual std::vector<std::vector<Complex>> contractA(const SlicedPropagator &A, const std::vector<SlicedPropagator> &B);
+    virtual std::vector<std::vector<Complex>> contract_A(const PropagatorField &GcuGl, const PropagatorField &GcuGr, const std::vector<Coordinate *> &xs, const std::vector<PropagatorField *> &ds_prop_pt);
 };
 
 MODULE_REGISTER_TMP(DMixingTopA, TDMixingTopA<FIMPL>, MContraction);
@@ -161,54 +159,33 @@ std::vector<std::string> TDMixingTopA<FImpl>::getOutputFiles(void)
 }
 
 template <typename FImpl>
-typename TDMixingTopA<FImpl>::SlicedPropagator TDMixingTopA<FImpl>::contractA_half_l(const TDMixingTopA<FImpl>::PropagatorField &GcuG, const std::vector<Coordinate *> &xs)
+std::vector<std::vector<Complex>> TDMixingTopA<FImpl>::contract_A(
+    const typename TDMixingTopA<FImpl>::PropagatorField &GcuG_l,
+    const typename TDMixingTopA<FImpl>::PropagatorField &GcuG_r,
+    const std::vector<Coordinate *> &xs,
+    const std::vector<typename TDMixingTopA<FImpl>::PropagatorField *> &ds_prop_pt)
 {
-    int Nt = GcuG.Grid()->_fdimensions[3];
-    SlicedPropagator A(Nt);
-
-    for (int t1 = 0; t1 < Nt; t1++)
-    {
-        A[t1] = peekSite(GcuG, *xs[t1]);
-    }
-
-    return A;
-}
-
-template <typename FImpl>
-std::vector<typename TDMixingTopA<FImpl>::SlicedPropagator> TDMixingTopA<FImpl>::contractA_half_r(const TDMixingTopA<FImpl>::PropagatorField &GcuG, const std::vector<typename TDMixingTopA<FImpl>::PropagatorField *> &ds_prop_pt)
-{
-    int Nt = GcuG.Grid()->_fdimensions[3];
+    int Nt = GcuG_l.Grid()->_fdimensions[3];
     Gamma g5(Gamma::Algebra::Gamma5);
-    std::vector<SlicedPropagator> B(Nt, SlicedPropagator(Nt));
-    SlicedPropagator buf;
-
-    for (int t1 = 0; t1 < Nt; t1++)
-    {
-        const auto &ds = *ds_prop_pt[t1];
-        PropagatorField tmp = g5 * adj(ds) * g5 * GcuG * ds;
-        sliceSum(tmp, buf, Tp);
-        for (int t2 = 0; t2 < Nt; t2++)
-        {
-            B[t1][t2] = buf[t2];
-        }
-    }
-
-    return B;
-}
-
-template <typename FImpl>
-std::vector<std::vector<Complex>> TDMixingTopA<FImpl>::contractA(const typename TDMixingTopA<FImpl>::SlicedPropagator &A, const std::vector<typename TDMixingTopA<FImpl>::SlicedPropagator> &B)
-{
-    int Nt = A.size();
-
     std::vector<std::vector<Complex>> corr(Nt, std::vector<Complex>(Nt));
+
+    SlicedPropagator B;
+    B.reserve(Nt);
+
     for (int t1 = 0; t1 < Nt; t1++)
     {
+        const auto A = peekSite(GcuG_l, *xs[t1]);
+
+        const auto &ds = *ds_prop_pt[t1];
+        const auto dsD = g5 * adj(ds) * g5;
+
+        PropagatorField tmp = dsD * GcuG_r * ds;
+        sliceSum(tmp, B, Tp);
+
         for (int t2 = 0; t2 < Nt; t2++)
-        {
-            corr[t1][t2] = TensorRemove(trace(A[t1] * B[t1][t2]));
-        }
+            corr[t1][t2] = TensorRemove(trace(A * B[t2]));
     }
+
     return corr;
 }
 
@@ -220,9 +197,8 @@ void TDMixingTopA<FImpl>::setup(void)
     envTmpLat(PropagatorField, "qcur");
     envTmp(std::vector<PropagatorField>, "GcuG_l", 1, 2, PropagatorField(env().getGrid()));
     envTmp(std::vector<PropagatorField>, "GcuG_r", 1, 2, PropagatorField(env().getGrid()));
-    const int Nt{env().getDim(Tdir)};
-    envTmp(std::vector<SlicedPropagator>, "half_l", 1, 2, SlicedPropagator(Nt));
-    envTmp(std::vector<std::vector<SlicedPropagator>>, "half_r", 1, 2, std::vector<SlicedPropagator>(Nt, SlicedPropagator(Nt)));
+    envTmpLat(PropagatorField, "half_l");
+    envTmpLat(PropagatorField, "half_r");
 
     envCreate(HadronsSerializable, getName(), 1, 0);
 }
@@ -240,7 +216,6 @@ void TDMixingTopA<FImpl>::execute(void)
     LOG(Message) << "points  : " << par().points << std::endl;
 
     std::vector<Result> result;
-    Result res;
 
     const int Nt{env().getDim(Tdir)};
     GridCartesian *grid = envGetGrid(FermionField);
@@ -249,20 +224,20 @@ void TDMixingTopA<FImpl>::execute(void)
     auto &qcl = envGet(PropagatorField, par().qCLeft);
     auto &qur = envGet(PropagatorField, par().qURight);
     auto &qcr = envGet(PropagatorField, par().qCRight);
-    auto &qi = envGet(std::vector<PropagatorField *>, par().qInt);
-    auto &points = envGet(std::vector<Coordinate *>, par().points);
+    auto &qin = envGet(std::vector<PropagatorField *>, par().qInt);
+    auto &pts = envGet(std::vector<Coordinate *>, par().points);
 
     envGetTmp(PropagatorField, qcul);
     envGetTmp(PropagatorField, qcur);
     envGetTmp(std::vector<PropagatorField>, GcuG_l);
     envGetTmp(std::vector<PropagatorField>, GcuG_r);
-    envGetTmp(std::vector<SlicedPropagator>, half_l);
-    envGetTmp(std::vector<std::vector<SlicedPropagator>>, half_r);
+    envGetTmp(PropagatorField, half_l);
+    envGetTmp(PropagatorField, half_r);
 
     Gamma g5(Gamma::Algebra::Gamma5);
 
-    qcul = qcl * g5 * g5 * adj(qul) * g5;
-    qcur = qcr * g5 * g5 * adj(qur) * g5;
+    qcul = qcl * adj(qul) * g5; // qcl * g5 * (g5 * adj(qul) * g5)
+    qcur = qcr * adj(qur) * g5; // qcr * g5 * (g5 * adj(qur) * g5)
 
     // parity +, parity -  (multiplying from left)
     const auto &GHpar = DMixingUtils<FImpl>::parityG;
@@ -272,21 +247,19 @@ void TDMixingTopA<FImpl>::execute(void)
 
     for (int p = 0; p < 2; p++)
     {
-        res.info.parity = (p == 0) ? "+" : "-";
+        for (int r = 0; r < 2; r++)
+        {
+            half_l = GHpar[p] * GcuG_l[r];
 
-        for (int r = 0; r < 2; r++)
-        {
-            half_l[r] = contractA_half_l(GHpar[p] * GcuG_l[r], points);
-            half_r[r] = contractA_half_r(GHpar[p] * GcuG_r[r], qi);
-        }
-        for (int r = 0; r < 2; r++)
-        {
             for (int s = 0; s < 2; s++)
             {
+                half_r = GHpar[p] * GcuG_r[s];
+
+                Result res;
+                res.info.parity = (p == 0) ? "+" : "-";
                 res.info.rr = std::to_string(r + 1) + std::to_string(s + 1);
 
-                res.corr.clear();
-                res.corr = contractA(half_l[r], half_r[s]);
+                res.corr = contract_A(half_l, half_r, pts, qin);
                 result.push_back(res);
             }
         }

--- a/Hadrons/Modules/MContraction/DMixingTopB.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopB.hpp
@@ -205,9 +205,7 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
         {
             for (const auto &GH2 : GHs)
             {
-                auto L = trA * GH2;
-                auto R = trB * parity * GH2;
-                LatticeComplex tmp = trace(L) * trace(R);
+                LatticeComplex tmp = trace(trA * GH2) * trace(trB * parity * GH2);
                 sliceSum(tmp, buf, Tp);
                 auto &row = corr[t1];
                 for (int t2 = 0; t2 < Nt; t2++)
@@ -219,8 +217,7 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
         {
             for (const auto &GH2 : GHs)
             {
-                auto prod = trA * GH2 * trB * parity * GH2;
-                LatticeComplex tmp = trace(prod);
+                LatticeComplex tmp = trace(trA * GH2 * trB * parity * GH2);
                 sliceSum(tmp, buf, Tp);
                 auto &row = corr[t1];
                 for (int t2 = 0; t2 < Nt; t2++)

--- a/Hadrons/Modules/MContraction/DMixingTopB.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopB.hpp
@@ -194,8 +194,8 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
 
     for (int t1 = 0; t1 < Nt; t1++)
     {
-        const auto &ds = *ds_prop_pt[t1];
-        const auto dsD = g5 * adj(ds) * g5;
+        const PropagatorField &ds = *ds_prop_pt[t1];
+        const PropagatorField dsD = g5 * adj(ds) * g5;
 
         const PropagatorField cui = peekSite(ci, *xs[t1]) * adj(ui) * g5;
         const PropagatorField cuf = cf * adj(peekSite(uf, *xs[t1])) * g5;

--- a/Hadrons/Modules/MContraction/DMixingTopB.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopB.hpp
@@ -111,7 +111,16 @@ public:
     // execution
     virtual void execute(void);
     // bespoke subcontractions
-    virtual std::vector<std::vector<Complex>> contract_B(const PropagatorField &ci, const PropagatorField &ui, const PropagatorField &cf, const PropagatorField &uf, const std::vector<PropagatorField *> &ds_prop_pt, const std::vector<Coordinate *> &xs, const int p, const int rL, const int rR);
+    virtual std::vector<std::vector<Complex>> contract_B(
+        const PropagatorField &ci,
+        const PropagatorField &ui,
+        const PropagatorField &cf,
+        const PropagatorField &uf,
+        const std::vector<PropagatorField *> &ds_prop_pt,
+        const std::vector<Coordinate *> &xs,
+        const int p,
+        const int rL,
+        const int rR);
 };
 
 MODULE_REGISTER_TMP(DMixingTopB, TDMixingTopB<FIMPL>, MContraction);
@@ -223,8 +232,8 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
         {
             for (const auto &GH1 : GHs)
             {
-                const auto trA = ds * parity * GH1 * cui;
-                const auto trB = cuf * GH1 * dsD;
+                PropagatorField trA = ds * parity * GH1 * cui;
+                PropagatorField trB = cuf * GH1 * dsD;
                 same_r ? tr_same(trA, trB) : tr_diff(trA, trB);
             }
         }
@@ -232,8 +241,8 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
         {
             for (const auto &GH1 : GHs)
             {
-                const auto trA = cuf * GH1 * cui;
-                const auto trB = ds * parity * GH1 * dsD;
+                PropagatorField trA = cuf * GH1 * cui;
+                PropagatorField trB = ds * parity * GH1 * dsD;
                 same_r ? tr_same(trA, trB) : tr_diff(trA, trB);
             }
         }

--- a/Hadrons/Modules/MContraction/DMixingTopB.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopB.hpp
@@ -111,7 +111,7 @@ public:
     // execution
     virtual void execute(void);
     // bespoke subcontractions
-    virtual std::vector<std::vector<Complex>> contractB(const PropagatorField &ci, const PropagatorField &ui, const PropagatorField &cf, const PropagatorField &uf, const std::vector<PropagatorField *> &ds_prop_pt, const std::vector<Coordinate *> &xs, const int p, const int rL, const int rR);
+    virtual std::vector<std::vector<Complex>> contract_B(const PropagatorField &ci, const PropagatorField &ui, const PropagatorField &cf, const PropagatorField &uf, const std::vector<PropagatorField *> &ds_prop_pt, const std::vector<Coordinate *> &xs, const int p, const int rL, const int rR);
 };
 
 MODULE_REGISTER_TMP(DMixingTopB, TDMixingTopB<FIMPL>, MContraction);
@@ -159,7 +159,7 @@ std::vector<std::string> TDMixingTopB<FImpl>::getOutputFiles(void)
 }
 
 template <typename FImpl>
-std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contractB(
+std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
     const TDMixingTopB<FImpl>::PropagatorField &ci,
     const TDMixingTopB<FImpl>::PropagatorField &ui,
     const TDMixingTopB<FImpl>::PropagatorField &cf,
@@ -175,50 +175,66 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contractB(
 
     std::vector<std::vector<Complex>> corr(Nt, std::vector<Complex>(Nt, 0.));
     std::vector<TComplex> buf;
+    buf.reserve(Nt);
 
     const auto &GHs = DMixingUtils<FImpl>::GHs;
     const auto &GHpar = DMixingUtils<FImpl>::parityG;
+    const Gamma parity = GHpar[p];
 
-    const bool same_r = rR == rL;
+    const bool same_r = (rR == rL);
 
     for (int t1 = 0; t1 < Nt; t1++)
     {
-
         const auto &ds = *ds_prop_pt[t1];
-        const PropagatorField dsD = g5 * adj(ds) * g5;
+        const auto dsD = g5 * adj(ds) * g5;
 
         const PropagatorField cui = peekSite(ci, *xs[t1]) * adj(ui) * g5;
         const PropagatorField cuf = cf * adj(peekSite(uf, *xs[t1])) * g5;
 
-        for (const auto &GH1 : GHs)
+        // product of traces
+        auto tr_same = [&](const auto &trA, const auto &trB)
         {
-            const PropagatorField trA = (rL == 0)
-                                            ? PropagatorField(ds * GHpar[p] * GH1 * cui)
-                                            : PropagatorField(cuf * GH1 * cui);
-
-            const PropagatorField trB = (rL == 0)
-                                            ? PropagatorField(cuf * GH1 * dsD)
-                                            : PropagatorField(ds * GHpar[p] * GH1 * dsD);
-
-            if (same_r) // product of traces
+            for (const auto &GH2 : GHs)
             {
-                for (const auto &GH2 : GHs)
-                {
-                    LatticeComplex tmp = trace(trA * GH2) * trace(trB * GHpar[p] * GH2);
-                    sliceSum(tmp, buf, Tp);
-                    for (int t2 = 0; t2 < Nt; ++t2)
-                        corr[t1][t2] += TensorRemove(buf[t2]);
-                }
+                auto L = trA * GH2;
+                auto R = trB * parity * GH2;
+                LatticeComplex tmp = trace(L) * trace(R);
+                sliceSum(tmp, buf, Tp);
+                auto &row = corr[t1];
+                for (int t2 = 0; t2 < Nt; t2++)
+                    row[t2] += TensorRemove(buf[t2]);
             }
-            else // trace of product
+        };
+        // trace of product
+        auto tr_diff = [&](const auto &trA, const auto &trB)
+        {
+            for (const auto &GH2 : GHs)
             {
-                for (const auto &GH2 : GHs)
-                {
-                    LatticeComplex tmp = trace(trA * GH2 * trB * GHpar[p] * GH2);
-                    sliceSum(tmp, buf, Tp);
-                    for (int t2 = 0; t2 < Nt; ++t2)
-                        corr[t1][t2] += TensorRemove(buf[t2]);
-                }
+                auto prod = trA * GH2 * trB * parity * GH2;
+                LatticeComplex tmp = trace(prod);
+                sliceSum(tmp, buf, Tp);
+                auto &row = corr[t1];
+                for (int t2 = 0; t2 < Nt; t2++)
+                    row[t2] += TensorRemove(buf[t2]);
+            }
+        };
+
+        if (rL == 0)
+        {
+            for (const auto &GH1 : GHs)
+            {
+                const auto trA = ds * parity * GH1 * cui;
+                const auto trB = cuf * GH1 * dsD;
+                same_r ? tr_same(trA, trB) : tr_diff(trA, trB);
+            }
+        }
+        else
+        {
+            for (const auto &GH1 : GHs)
+            {
+                const auto trA = cuf * GH1 * cui;
+                const auto trB = ds * parity * GH1 * dsD;
+                same_r ? tr_same(trA, trB) : tr_diff(trA, trB);
             }
         }
     }
@@ -246,29 +262,25 @@ void TDMixingTopB<FImpl>::execute(void)
     LOG(Message) << "points  : " << par().points << std::endl;
 
     std::vector<Result> result;
-    Result res;
-
-    const int Nt{env().getDim(Tdir)};
 
     auto &qul = envGet(PropagatorField, par().qULeft);
     auto &qcl = envGet(PropagatorField, par().qCLeft);
     auto &qur = envGet(PropagatorField, par().qURight);
     auto &qcr = envGet(PropagatorField, par().qCRight);
-    auto &qi = envGet(std::vector<PropagatorField *>, par().qInt);
-    auto &points = envGet(std::vector<Coordinate *>, par().points);
+    auto &qin = envGet(std::vector<PropagatorField *>, par().qInt);
+    auto &pts = envGet(std::vector<Coordinate *>, par().points);
 
     for (int p = 0; p < 2; p++)
     {
-        res.info.parity = (p == 0) ? "+" : "-";
-
         for (int r = 0; r < 2; r++)
         {
             for (int s = 0; s < 2; s++)
             {
+                Result res;
+                res.info.parity = (p == 0) ? "+" : "-";
                 res.info.rr = std::to_string(r + 1) + std::to_string(s + 1);
 
-                res.corr.clear();
-                res.corr = contractB(qcl, qul, qcr, qur, qi, points, p, r, s);
+                res.corr = contract_B(qcl, qul, qcr, qur, qin, pts, p, r, s);
                 result.push_back(res);
             }
         }

--- a/Hadrons/Modules/MContraction/DMixingTopC.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopC.hpp
@@ -155,17 +155,17 @@ std::vector<Complex> TDMixingTopC<FImpl>::contract_C_half(const TDMixingTopC<FIm
 {
     Gamma g5(Gamma::Algebra::Gamma5);
 
-    Gamma Gsrc = g5;
-
-    LatticeComplex tmp = trace(prop_c * Gsrc * g5 * adj(prop_u) * g5 * loop);
+    LatticeComplex tmp = trace(prop_c * adj(prop_u) * g5 * loop);
     SlicedComplex ret;
     sliceSum(tmp, ret, Tp);
-    std::vector<Complex> ret2(ret.size());
-    for (unsigned int t = 0; t < env().getDim(Tdir); ++t)
+
+    const int Nt{env().getDim(Tdir)};
+    std::vector<Complex> out(Nt);
+    for (unsigned int t = 0; t < Nt; t++)
     {
-        ret2[t] = TensorRemove(ret[t]);
+        out[t] = TensorRemove(ret[t]);
     }
-    return ret2;
+    return out;
 };
 
 // setup ///////////////////////////////////////////////////////////////////////
@@ -174,7 +174,7 @@ void TDMixingTopC<FImpl>::setup(void)
 {
     GridCartesian *grid = envGetGrid(FermionField);
     envTmp(std::vector<PropagatorField>, "GdsG", 1, 2, PropagatorField(env().getGrid()));
-    envTmpLat(ComplexField, "corr");
+
     envCreate(HadronsSerializable, getName(), 1, 0);
 }
 
@@ -188,7 +188,6 @@ void TDMixingTopC<FImpl>::execute(void)
     LOG(Message) << "qLoop1  : " << par().qLoop1 << std::endl;
 
     std::vector<Result> result;
-    Result res;
 
     const int Nt{env().getDim(Tdir)};
     GridCartesian *grid = envGetGrid(FermionField);
@@ -198,25 +197,23 @@ void TDMixingTopC<FImpl>::execute(void)
     auto &ql1 = envGet(std::vector<PropagatorField *>, par().qLoop1);
 
     int Neta = ql1.size();
-    
+
     envGetTmp(std::vector<PropagatorField>, GdsG);
 
     for (int p = 0; p < 2; p++)
     {
-        res.info.parity = (p == 0) ? "+" : "-";
-        
         for (int i = 0; i < Neta; i++)
         {
-            res.info.eta = std::to_string(i);
-
             // here one has to add ql2 if one wants them to be allowed to be different
             DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[i], p);
 
             for (int r = 0; r < 2; r++)
             {
-                res.info.r = std::to_string(r + 1);    
+                Result res;
+                res.info.parity = (p == 0) ? "+" : "-";
+                res.info.eta = std::to_string(i);
+                res.info.r = std::to_string(r + 1);
 
-                res.corr.clear();
                 res.corr = contract_C_half(qcl, qul, GdsG[r]);
                 result.push_back(res);
             }

--- a/Hadrons/Modules/MContraction/DMixingTopC.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopC.hpp
@@ -105,7 +105,10 @@ public:
     // execution
     virtual void execute(void);
     // bespoke subcontractions
-    virtual std::vector<Complex> contract_C_half(const PropagatorField &prop_c, const PropagatorField &prop_u, const PropagatorField &loop);
+    virtual std::vector<Complex> contract_C_half(
+        const PropagatorField &prop_c,
+        const PropagatorField &prop_u_adj,
+        const PropagatorField &loop);
 };
 
 MODULE_REGISTER_TMP(DMixingTopC, TDMixingTopC<FIMPL>, MContraction);
@@ -151,11 +154,14 @@ std::vector<std::string> TDMixingTopC<FImpl>::getOutputFiles(void)
 }
 
 template <typename FImpl>
-std::vector<Complex> TDMixingTopC<FImpl>::contract_C_half(const TDMixingTopC<FImpl>::PropagatorField &prop_c, const TDMixingTopC<FImpl>::PropagatorField &prop_u, const TDMixingTopC<FImpl>::PropagatorField &loop)
+std::vector<Complex> TDMixingTopC<FImpl>::contract_C_half(
+    const TDMixingTopC<FImpl>::PropagatorField &prop_c,
+    const TDMixingTopC<FImpl>::PropagatorField &prop_u_adj,
+    const TDMixingTopC<FImpl>::PropagatorField &loop)
 {
     Gamma g5(Gamma::Algebra::Gamma5);
 
-    LatticeComplex tmp = trace(prop_c * adj(prop_u) * g5 * loop);
+    LatticeComplex tmp = trace(prop_c * g5 * prop_u_adj * loop);
     SlicedComplex ret;
     sliceSum(tmp, ret, Tp);
 
@@ -196,6 +202,9 @@ void TDMixingTopC<FImpl>::execute(void)
     auto &qcl = envGet(PropagatorField, par().qCLeft);
     auto &ql1 = envGet(std::vector<PropagatorField *>, par().qLoop1);
 
+    Gamma g5(Gamma::Algebra::Gamma5);
+    const PropagatorField qul_adj = g5 * adj(qul) * g5;
+
     int Neta = ql1.size();
 
     envGetTmp(std::vector<PropagatorField>, GdsG);
@@ -214,7 +223,7 @@ void TDMixingTopC<FImpl>::execute(void)
                 res.info.eta = std::to_string(i);
                 res.info.r = std::to_string(r + 1);
 
-                res.corr = contract_C_half(qcl, qul, GdsG[r]);
+                res.corr = contract_C_half(qcl, qul_adj, GdsG[r]);
                 result.push_back(res);
             }
         }

--- a/Hadrons/Modules/MContraction/DMixingTopD.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopD.hpp
@@ -187,6 +187,7 @@ std::vector<std::vector<Complex>> TDMixingTopD<FImpl>::contract_D(
 
     int Nt = half_l.size();
     std::vector<std::vector<Complex>> corr(Nt, std::vector<Complex>(Nt));
+
     for (int t1 = 0; t1 < Nt; t1++)
     {
         for (int t2 = 0; t2 < Nt; t2++)
@@ -256,12 +257,14 @@ void TDMixingTopD<FImpl>::execute(void)
     envGetTmp(std::vector<SlicedPropagator>, half_r);
     envGetTmp(std::vector<PropagatorField>, GdsG);
 
-    std::vector<std::vector<Complex>> tmpRes = std::vector<std::vector<Complex>>(Nt, std::vector<Complex>(Nt, 0.));
-    std::vector<std::vector<Complex>> tmpSum = std::vector<std::vector<Complex>>(Nt, std::vector<Complex>(Nt, 0.));
+    std::vector<std::vector<Complex>> tmpRes(Nt, std::vector<Complex>(Nt, 0.));
+    std::vector<std::vector<Complex>> tmpSum(Nt, std::vector<Complex>(Nt, 0.));
+    std::vector<std::vector<Complex>> diagSum(Nt, std::vector<Complex>(Nt, 0.));
+
+    SlicedPropagator Lsum(Nt), Rsum(Nt);
 
     for (int p = 0; p < 2; p++)
     {
-
         for (int i = 0; i < Neta; i++)
         {
             // here one has to add ql2 if one wants them to be allowed to be different
@@ -277,39 +280,37 @@ void TDMixingTopD<FImpl>::execute(void)
         {
             for (int s = 0; s < 2; s++)
             {
-                for (auto &row : tmpSum)
-                    std::fill(row.begin(), row.end(), Complex(0.0));
+                for (int t = 0; t < Nt; t++)
+                {
+                    Lsum[t] = Zero();
+                    Rsum[t] = Zero();
+                    if (same_loop_noise)
+                        std::fill(diagSum[t].begin(), diagSum[t].end(), Complex(0.0));
+                }
 
                 for (int i = 0; i < Neta; i++) // imax = i + 1
                 {
-                    for (int j = 0; j < i; j++)
-                    {
-                        const auto &c1 =
-                            contract_D(half_lr[i + Neta * r], half_rl[j + Neta * s]);
-                        const auto &c2 =
-                            contract_D(half_lr[j + Neta * r], half_rl[i + Neta * s]);
+                    const auto &Li = half_l[i + Neta * r];
+                    const auto &Ri = half_r[i + Neta * s];
 
-                        // Symmetrize
-                        for (int t1 = 0; t1 < Nt; t1++)
-                        {
-                            for (int t2 = 0; t2 < Nt; t2++)
-                            {
-                                tmpSum[t1][t2] += c1[t1][t2] + c2[t1][t2];
-                            }
-                        }
-                    }
-                    if (!same_loop_noise)
+                    // accumulate sums of Li, Ri
+                    for (int t = 0; t < Nt; t++)
                     {
-                        // Add diagonal term
-                        const auto &c_diag =
-                            contract_D(half_lr[i + Neta * r], half_rl[i + Neta * s]);
+                        Lsum[t] += Li[t];
+                        Rsum[t] += Ri[t];
+                    }
+                    tmpSum = contract_D(Lsum, Rsum);
+
+                    if (same_loop_noise)
+                    {
+                        // accumulate sum of diagonal terms & remove from total
+                        const auto &diag = contract_D(Li, Ri);
                         for (int t1 = 0; t1 < Nt; t1++)
-                        {
                             for (int t2 = 0; t2 < Nt; t2++)
                             {
-                                tmpSum[t1][t2] += c_diag[t1][t2];
+                                diagSum[t1][t2] += diag[t1][t2];
+                                tmpSum[t1][t2] -= diagSum[t1][t2];
                             }
-                        }
                     }
 
                     const double norm = (!same_loop_noise)

--- a/Hadrons/Modules/MContraction/DMixingTopD.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopD.hpp
@@ -117,8 +117,8 @@ public:
                                  const PropagatorField &loop,
                                  SlicedPropagator &out);
     virtual void contract_D(const SlicedPropagator &half_lr,
-                           const SlicedPropagator &half_rl,
-                           std::vector<std::vector<Complex>> &sum);
+                            const SlicedPropagator &half_rl,
+                            std::vector<std::vector<Complex>> &sum);
 };
 
 MODULE_REGISTER_TMP(DMixingTopD, TDMixingTopD<FIMPL>, MContraction);
@@ -204,7 +204,8 @@ void TDMixingTopD<FImpl>::setup(void)
     envTmpLat(PropagatorField, "half_rl_i");
     envTmpLat(PropagatorField, "half_lr_j");
     envTmpLat(PropagatorField, "half_rl_j");
-    envTmp(std::vector<PropagatorField>, "GdsG", 1, 2, PropagatorField(env().getGrid()));
+    // envTmp(std::vector<PropagatorField>, "GdsG", 1, 2, PropagatorField(env().getGrid()));
+    envTmpLat(PropagatorField, "GdsG");
 
     if (par().qLoop1 != par().qLoop2)
     {
@@ -245,7 +246,8 @@ void TDMixingTopD<FImpl>::execute(void)
     envGetTmp(SlicedPropagator, half_rl_i);
     envGetTmp(SlicedPropagator, half_lr_j);
     envGetTmp(SlicedPropagator, half_rl_j);
-    envGetTmp(std::vector<PropagatorField>, GdsG);
+    // envGetTmp(std::vector<PropagatorField>, GdsG);
+    envGetTmp(PropagatorField, GdsG);
 
     std::vector<std::vector<Complex>> tmpRes = std::vector<std::vector<Complex>>(Nt, std::vector<Complex>(Nt, 0.));
     std::vector<std::vector<Complex>> tmpSum = std::vector<std::vector<Complex>>(Nt, std::vector<Complex>(Nt, 0.));
@@ -261,16 +263,19 @@ void TDMixingTopD<FImpl>::execute(void)
 
                 for (int i = 0; i < Neta; i++) // imax = i + 1
                 {
-                    DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[i], p);
+                    DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[i], p, r);
+                    contract_D_half(qcl, qur, GdsG, half_lr_i);
 
-                    contract_D_half(qcl, qur, GdsG[r], half_lr_i);
-                    contract_D_half(qcr, qul, GdsG[s], half_rl_i);
+                    DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[i], p, s);
+                    contract_D_half(qcr, qul, GdsG, half_rl_i);
 
                     for (int j = 0; j < i; j++)
                     {
-                        DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[j], p);
-                        contract_D_half(qcl, qur, GdsG[r], half_lr_j);
-                        contract_D_half(qcr, qul, GdsG[s], half_rl_j);
+                        DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[j], p, r);
+                        contract_D_half(qcl, qur, GdsG, half_lr_j);
+
+                        DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[j], p, s);
+                        contract_D_half(qcr, qul, GdsG, half_rl_j);
 
                         contract_D(half_lr_i, half_rl_j, tmpSum);
                         contract_D(half_lr_j, half_rl_i, tmpSum);

--- a/Hadrons/Modules/MContraction/DMixingTopD.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopD.hpp
@@ -114,7 +114,7 @@ public:
     // bespoke subcontractions
     virtual SlicedPropagator contract_D_half(
         const PropagatorField &prop_c,
-        const PropagatorField &prop_u,
+        const PropagatorField &prop_u_adj,
         const PropagatorField &loop);
     virtual std::vector<std::vector<Complex>> contract_D(
         const SlicedPropagator &half_if,
@@ -167,33 +167,31 @@ std::vector<std::string> TDMixingTopD<FImpl>::getOutputFiles(void)
 }
 
 template <typename FImpl>
-typename TDMixingTopD<FImpl>::SlicedPropagator TDMixingTopD<FImpl>::contract_D_half(const TDMixingTopD<FImpl>::PropagatorField &prop_c, const TDMixingTopD<FImpl>::PropagatorField &prop_u, const TDMixingTopD<FImpl>::PropagatorField &loop)
+typename TDMixingTopD<FImpl>::SlicedPropagator TDMixingTopD<FImpl>::contract_D_half(
+    const TDMixingTopD<FImpl>::PropagatorField &prop_c,
+    const TDMixingTopD<FImpl>::PropagatorField &prop_u_adj,
+    const TDMixingTopD<FImpl>::PropagatorField &loop)
 {
-    Gamma g5(Gamma::Algebra::Gamma5);
-
-    PropagatorField tmp = g5 * adj(prop_u) * g5 * loop * prop_c;
+    PropagatorField tmp = prop_u_adj * loop * prop_c;
     SlicedPropagator out;
     sliceSum(tmp, out, Tp);
     return out;
 };
 
 template <typename FImpl>
-std::vector<std::vector<Complex>> TDMixingTopD<FImpl>::contract_D(const typename TDMixingTopD<FImpl>::SlicedPropagator &half_lr, const typename TDMixingTopD<FImpl>::SlicedPropagator &half_rl)
+std::vector<std::vector<Complex>> TDMixingTopD<FImpl>::contract_D(
+    const typename TDMixingTopD<FImpl>::SlicedPropagator &half_l,
+    const typename TDMixingTopD<FImpl>::SlicedPropagator &half_r)
 {
     Gamma g5(Gamma::Algebra::Gamma5);
 
-    // Kept general in case anyone ever wants to play with this
-    Gamma Gsrc = g5;
-    Gamma Gsnk = Gsrc; // no conj on final interpolator for D-Dbar mixing
-
-    int Nt = half_lr.size();
-
+    int Nt = half_l.size();
     std::vector<std::vector<Complex>> corr(Nt, std::vector<Complex>(Nt));
     for (int t1 = 0; t1 < Nt; t1++)
     {
         for (int t2 = 0; t2 < Nt; t2++)
         {
-            corr[t1][t2] = TensorRemove(trace(half_lr[t1] * Gsrc * half_rl[t2] * Gsnk));
+            corr[t1][t2] = TensorRemove(trace(half_l[t1] * g5 * half_r[t2] * g5));
         }
     }
 
@@ -211,8 +209,8 @@ void TDMixingTopD<FImpl>::setup(void)
     int Neta = ql1.size();
     const int Nt = env().getDim(Tdir);
 
-    envTmp(std::vector<SlicedPropagator>, "half_lr", 1, 2 * Neta, SlicedPropagator(Nt));
-    envTmp(std::vector<SlicedPropagator>, "half_rl", 1, 2 * Neta, SlicedPropagator(Nt));
+    envTmp(std::vector<SlicedPropagator>, "half_l", 1, 2 * Neta, SlicedPropagator(Nt));
+    envTmp(std::vector<SlicedPropagator>, "half_r", 1, 2 * Neta, SlicedPropagator(Nt));
     envTmp(std::vector<PropagatorField>, "GdsG", 1, 2, PropagatorField(env().getGrid()));
 
     if (par().qLoop1 != par().qLoop2)
@@ -246,12 +244,16 @@ void TDMixingTopD<FImpl>::execute(void)
     auto &ql1 = envGet(std::vector<PropagatorField *>, par().qLoop1);
     auto &ql2 = envGet(std::vector<PropagatorField *>, par().qLoop2);
 
+    Gamma g5(Gamma::Algebra::Gamma5);
+    const PropagatorField qur_adj = g5 * adj(qur) * g5;
+    const PropagatorField qul_adj = g5 * adj(qul) * g5;
+
     // this is assuming both loops are identical
     int Neta = ql1.size();
     bool same_loop_noise = true;
 
-    envGetTmp(std::vector<SlicedPropagator>, half_lr);
-    envGetTmp(std::vector<SlicedPropagator>, half_rl);
+    envGetTmp(std::vector<SlicedPropagator>, half_l);
+    envGetTmp(std::vector<SlicedPropagator>, half_r);
     envGetTmp(std::vector<PropagatorField>, GdsG);
 
     std::vector<std::vector<Complex>> tmpRes = std::vector<std::vector<Complex>>(Nt, std::vector<Complex>(Nt, 0.));
@@ -266,8 +268,8 @@ void TDMixingTopD<FImpl>::execute(void)
             DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[i], p);
             for (int r = 0; r < 2; r++)
             {
-                half_lr[i + Neta * r] = contract_D_half(qcl, qur, GdsG[r]);
-                half_rl[i + Neta * r] = contract_D_half(qcr, qul, GdsG[r]);
+                half_l[i + Neta * r] = contract_D_half(qcl, qur_adj, GdsG[r]);
+                half_r[i + Neta * r] = contract_D_half(qcr, qul_adj, GdsG[r]);
             }
         }
 

--- a/Hadrons/Modules/MContraction/DMixingTopD.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopD.hpp
@@ -112,13 +112,13 @@ public:
     // execution
     virtual void execute(void);
     // bespoke subcontractions
-    virtual void contract_D_half(const PropagatorField &prop_c,
-                                 const PropagatorField &prop_u,
-                                 const PropagatorField &loop,
-                                 SlicedPropagator &out);
-    virtual void contract_D(const SlicedPropagator &half_lr,
-                            const SlicedPropagator &half_rl,
-                            std::vector<std::vector<Complex>> &sum);
+    virtual SlicedPropagator contract_D_half(
+        const PropagatorField &prop_c,
+        const PropagatorField &prop_u,
+        const PropagatorField &loop);
+    virtual std::vector<std::vector<Complex>> contract_D(
+        const SlicedPropagator &half_if,
+        const SlicedPropagator &half_fi);
 };
 
 MODULE_REGISTER_TMP(DMixingTopD, TDMixingTopD<FIMPL>, MContraction);
@@ -167,31 +167,38 @@ std::vector<std::string> TDMixingTopD<FImpl>::getOutputFiles(void)
 }
 
 template <typename FImpl>
-inline void TDMixingTopD<FImpl>::contract_D_half(
-    const typename TDMixingTopD<FImpl>::PropagatorField &prop_c,
-    const typename TDMixingTopD<FImpl>::PropagatorField &prop_u,
-    const typename TDMixingTopD<FImpl>::PropagatorField &loop,
-    SlicedPropagator &out)
+typename TDMixingTopD<FImpl>::SlicedPropagator TDMixingTopD<FImpl>::contract_D_half(const TDMixingTopD<FImpl>::PropagatorField &prop_c, const TDMixingTopD<FImpl>::PropagatorField &prop_u, const TDMixingTopD<FImpl>::PropagatorField &loop)
 {
     Gamma g5(Gamma::Algebra::Gamma5);
 
     PropagatorField tmp = g5 * adj(prop_u) * g5 * loop * prop_c;
+    SlicedPropagator out;
     sliceSum(tmp, out, Tp);
+    return out;
 };
 
 template <typename FImpl>
-void TDMixingTopD<FImpl>::contract_D(
-    const typename TDMixingTopD<FImpl>::SlicedPropagator &half_lr,
-    const typename TDMixingTopD<FImpl>::SlicedPropagator &half_rl,
-    std::vector<std::vector<Complex>> &sum)
+std::vector<std::vector<Complex>> TDMixingTopD<FImpl>::contract_D(const typename TDMixingTopD<FImpl>::SlicedPropagator &half_lr, const typename TDMixingTopD<FImpl>::SlicedPropagator &half_rl)
 {
     Gamma g5(Gamma::Algebra::Gamma5);
-    const int Nt = (int)half_lr.size();
 
+    // Kept general in case anyone ever wants to play with this
+    Gamma Gsrc = g5;
+    Gamma Gsnk = Gsrc; // no conj on final interpolator for D-Dbar mixing
+
+    int Nt = half_lr.size();
+
+    std::vector<std::vector<Complex>> corr(Nt, std::vector<Complex>(Nt));
     for (int t1 = 0; t1 < Nt; t1++)
+    {
         for (int t2 = 0; t2 < Nt; t2++)
-            sum[t1][t2] += TensorRemove(trace(half_lr[t1] * g5 * half_rl[t2] * g5));
-}
+        {
+            corr[t1][t2] = TensorRemove(trace(half_lr[t1] * Gsrc * half_rl[t2] * Gsnk));
+        }
+    }
+
+    return corr;
+};
 
 // setup ///////////////////////////////////////////////////////////////////////
 template <typename FImpl>
@@ -200,12 +207,13 @@ void TDMixingTopD<FImpl>::setup(void)
 
     GridCartesian *grid = envGetGrid(FermionField);
 
+    auto &ql1 = envGet(std::vector<PropagatorField *>, par().qLoop1);
+    int Neta = ql1.size();
     const int Nt = env().getDim(Tdir);
-    envTmp(SlicedPropagator, "half_lr_i", 1, Nt);
-    envTmp(SlicedPropagator, "half_lr_j", 1, Nt);
-    envTmp(SlicedPropagator, "half_rl_i", 1, Nt);
-    envTmp(SlicedPropagator, "half_rl_j", 1, Nt);
-    envTmpLat(PropagatorField, "GdsG");
+
+    envTmp(std::vector<SlicedPropagator>, "half_lr", 1, 2 * Neta, SlicedPropagator(Nt));
+    envTmp(std::vector<SlicedPropagator>, "half_rl", 1, 2 * Neta, SlicedPropagator(Nt));
+    envTmp(std::vector<PropagatorField>, "GdsG", 1, 2, PropagatorField(env().getGrid()));
 
     if (par().qLoop1 != par().qLoop2)
     {
@@ -242,17 +250,27 @@ void TDMixingTopD<FImpl>::execute(void)
     int Neta = ql1.size();
     bool same_loop_noise = true;
 
-    envGetTmp(SlicedPropagator, half_lr_i);
-    envGetTmp(SlicedPropagator, half_rl_i);
-    envGetTmp(SlicedPropagator, half_lr_j);
-    envGetTmp(SlicedPropagator, half_rl_j);
-    envGetTmp(PropagatorField, GdsG);
+    envGetTmp(std::vector<SlicedPropagator>, half_lr);
+    envGetTmp(std::vector<SlicedPropagator>, half_rl);
+    envGetTmp(std::vector<PropagatorField>, GdsG);
 
     std::vector<std::vector<Complex>> tmpRes = std::vector<std::vector<Complex>>(Nt, std::vector<Complex>(Nt, 0.));
     std::vector<std::vector<Complex>> tmpSum = std::vector<std::vector<Complex>>(Nt, std::vector<Complex>(Nt, 0.));
 
     for (int p = 0; p < 2; p++)
     {
+
+        for (int i = 0; i < Neta; i++)
+        {
+            // here one has to add ql2 if one wants them to be allowed to be different
+            DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[i], p);
+            for (int r = 0; r < 2; r++)
+            {
+                half_lr[i + Neta * r] = contract_D_half(qcl, qur, GdsG[r]);
+                half_rl[i + Neta * r] = contract_D_half(qcr, qul, GdsG[r]);
+            }
+        }
+
         for (int r = 0; r < 2; r++)
         {
             for (int s = 0; s < 2; s++)
@@ -262,27 +280,34 @@ void TDMixingTopD<FImpl>::execute(void)
 
                 for (int i = 0; i < Neta; i++) // imax = i + 1
                 {
-                    DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[i], p, r);
-                    contract_D_half(qcl, qur, GdsG, half_lr_i);
-
-                    DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[i], p, s);
-                    contract_D_half(qcr, qul, GdsG, half_rl_i);
-
                     for (int j = 0; j < i; j++)
                     {
-                        DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[j], p, r);
-                        contract_D_half(qcl, qur, GdsG, half_lr_j);
+                        const auto &c1 =
+                            contract_D(half_lr[i + Neta * r], half_rl[j + Neta * s]);
+                        const auto &c2 =
+                            contract_D(half_lr[j + Neta * r], half_rl[i + Neta * s]);
 
-                        DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[j], p, s);
-                        contract_D_half(qcr, qul, GdsG, half_rl_j);
-
-                        contract_D(half_lr_i, half_rl_j, tmpSum);
-                        contract_D(half_lr_j, half_rl_i, tmpSum);
+                        // Symmetrize
+                        for (int t1 = 0; t1 < Nt; t1++)
+                        {
+                            for (int t2 = 0; t2 < Nt; t2++)
+                            {
+                                tmpSum[t1][t2] += c1[t1][t2] + c2[t1][t2];
+                            }
+                        }
                     }
                     if (!same_loop_noise)
                     {
-                        // include diagonal term when loops use different noises
-                        contract_D(half_lr_i, half_rl_i, tmpSum);
+                        // Add diagonal term
+                        const auto &c_diag =
+                            contract_D(half_lr[i + Neta * r], half_rl[i + Neta * s]);
+                        for (int t1 = 0; t1 < Nt; t1++)
+                        {
+                            for (int t2 = 0; t2 < Nt; t2++)
+                            {
+                                tmpSum[t1][t2] += c_diag[t1][t2];
+                            }
+                        }
                     }
 
                     const double norm = (!same_loop_noise)

--- a/Hadrons/Modules/MContraction/DMixingTopD.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopD.hpp
@@ -56,7 +56,7 @@ BEGIN_HADRONS_NAMESPACE
  *
  * p = +: GA x GB =   V x V + A x A
  * p = -: GA x GB = - A x V - V x A
- * 
+ *
  * Contractions: [...] = tr(...)
  * rr' = 11:
  *  [qCR * g5 * qUR * GB1 * qLoop1 * GA1 * qCL * g5 * gUL * GB2 * gLoop2 * GA2]
@@ -112,8 +112,19 @@ public:
     // execution
     virtual void execute(void);
     // bespoke subcontractions
-    virtual SlicedPropagator contract_D_half(const PropagatorField &prop_c, const PropagatorField &prop_u, const PropagatorField &loop);
-    virtual std::vector<std::vector<Complex>> contract_D(const SlicedPropagator &half_if, const SlicedPropagator &half_fi);
+    // virtual SlicedPropagator contract_D_half(const PropagatorField &prop_c,
+    //                                          const PropagatorField &prop_u,
+    //                                          const PropagatorField &loop);
+    virtual void contract_D_half(const PropagatorField &prop_c,
+                                 const PropagatorField &prop_u,
+                                 const PropagatorField &loop,
+                                 SlicedPropagator &out);
+
+    // virtual std::vector<std::vector<Complex>> contract_D(const SlicedPropagator &half_if,
+    //                                                      const SlicedPropagator &half_fi);
+    virtual void contract_D(const SlicedPropagator &half_lr,
+                           const SlicedPropagator &half_rl,
+                           std::vector<std::vector<Complex>> &sum);
 };
 
 MODULE_REGISTER_TMP(DMixingTopD, TDMixingTopD<FIMPL>, MContraction);
@@ -162,38 +173,31 @@ std::vector<std::string> TDMixingTopD<FImpl>::getOutputFiles(void)
 }
 
 template <typename FImpl>
-typename TDMixingTopD<FImpl>::SlicedPropagator TDMixingTopD<FImpl>::contract_D_half(const TDMixingTopD<FImpl>::PropagatorField &prop_c, const TDMixingTopD<FImpl>::PropagatorField &prop_u, const TDMixingTopD<FImpl>::PropagatorField &loop)
+inline void TDMixingTopD<FImpl>::contract_D_half(
+    const typename TDMixingTopD<FImpl>::PropagatorField &prop_c,
+    const typename TDMixingTopD<FImpl>::PropagatorField &prop_u,
+    const typename TDMixingTopD<FImpl>::PropagatorField &loop,
+    SlicedPropagator &out)
 {
     Gamma g5(Gamma::Algebra::Gamma5);
 
     PropagatorField tmp = g5 * adj(prop_u) * g5 * loop * prop_c;
-    SlicedPropagator ret;
-    sliceSum(tmp, ret, Tp);
-    return ret;
+    sliceSum(tmp, out, Tp);
 };
 
 template <typename FImpl>
-std::vector<std::vector<Complex>> TDMixingTopD<FImpl>::contract_D(const typename TDMixingTopD<FImpl>::SlicedPropagator &half_lr, const typename TDMixingTopD<FImpl>::SlicedPropagator &half_rl)
+void TDMixingTopD<FImpl>::contract_D(
+    const typename TDMixingTopD<FImpl>::SlicedPropagator &half_lr,
+    const typename TDMixingTopD<FImpl>::SlicedPropagator &half_rl,
+    std::vector<std::vector<Complex>> &sum)
 {
     Gamma g5(Gamma::Algebra::Gamma5);
+    const int Nt = (int)half_lr.size();
 
-    // Kept general in case anyone ever wants to play with this
-    Gamma Gsrc = g5;
-    Gamma Gsnk = Gsrc; // no conj on final interpolator for D-Dbar mixing
-
-    int Nt = half_lr.size();
-
-    std::vector<std::vector<Complex>> corr(Nt, std::vector<Complex>(Nt));
     for (int t1 = 0; t1 < Nt; t1++)
-    {
         for (int t2 = 0; t2 < Nt; t2++)
-        {
-            corr[t1][t2] = TensorRemove(trace(half_lr[t1] * Gsrc * half_rl[t2] * Gsnk));
-        }
-    }
-
-    return corr;
-};
+            sum[t1][t2] += TensorRemove(trace(half_lr[t1] * g5 * half_rl[t2] * g5));
+}
 
 // setup ///////////////////////////////////////////////////////////////////////
 template <typename FImpl>
@@ -201,11 +205,11 @@ void TDMixingTopD<FImpl>::setup(void)
 {
 
     GridCartesian *grid = envGetGrid(FermionField);
-    auto &ql1 = envGet(std::vector<PropagatorField *>, par().qLoop1);
-    int Neta = ql1.size();
-    const int Nt{env().getDim(Tdir)};
-    envTmp(std::vector<SlicedPropagator>, "half_lr", 1, 2 * Neta, SlicedPropagator(Nt));
-    envTmp(std::vector<SlicedPropagator>, "half_rl", 1, 2 * Neta, SlicedPropagator(Nt));
+
+    envTmpLat(PropagatorField, "half_lr_i");
+    envTmpLat(PropagatorField, "half_rl_i");
+    envTmpLat(PropagatorField, "half_lr_j");
+    envTmpLat(PropagatorField, "half_rl_j");
     envTmp(std::vector<PropagatorField>, "GdsG", 1, 2, PropagatorField(env().getGrid()));
 
     if (par().qLoop1 != par().qLoop2)
@@ -228,7 +232,6 @@ void TDMixingTopD<FImpl>::execute(void)
     LOG(Message) << "qLoop2  : " << par().qLoop2 << std::endl;
 
     std::vector<Result> result;
-    Result res;
 
     const int Nt{env().getDim(Tdir)};
     GridCartesian *grid = envGetGrid(FermionField);
@@ -244,8 +247,10 @@ void TDMixingTopD<FImpl>::execute(void)
     int Neta = ql1.size();
     bool same_loop_noise = true;
 
-    envGetTmp(std::vector<SlicedPropagator>, half_lr);
-    envGetTmp(std::vector<SlicedPropagator>, half_rl);
+    envGetTmp(SlicedPropagator, half_lr_i);
+    envGetTmp(SlicedPropagator, half_rl_i);
+    envGetTmp(SlicedPropagator, half_lr_j);
+    envGetTmp(SlicedPropagator, half_rl_j);
     envGetTmp(std::vector<PropagatorField>, GdsG);
 
     std::vector<std::vector<Complex>> tmpRes = std::vector<std::vector<Complex>>(Nt, std::vector<Complex>(Nt, 0.));
@@ -253,75 +258,47 @@ void TDMixingTopD<FImpl>::execute(void)
 
     for (int p = 0; p < 2; p++)
     {
-        res.info.parity = (p == 0) ? "+" : "-";
-        
-        for (int i = 0; i < Neta; i++)
+        for (int r = 0; r < 2; ++r)
         {
-            // here one has to add ql2 if one wants them to be allowed to be different
-            DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[i], p);
-            for (int r = 0; r < 2; r++)
+            for (int s = 0; s < 2; ++s)
             {
-                half_lr[i + Neta * r] = contract_D_half(qcl, qur, GdsG[r]);
-                half_rl[i + Neta * r] = contract_D_half(qcr, qul, GdsG[r]);
-            }
-        }
-
-        for (int r = 0; r < 2; r++)
-        {
-            for (int s = 0; s < 2; s++)
-            {
-                res.info.rr = std::to_string(r + 1) + std::to_string(s + 1);
-
-                // Initialise tmpSum for each (p,r,s) combination
                 for (auto &row : tmpSum)
                     std::fill(row.begin(), row.end(), Complex(0.0));
 
-                // Average noise up to imax (+ add diagonal when loops are different)
-                for (int imax = 1; imax <= Neta; imax++)
+                for (int i = 0; i < Neta; i++) // imax = i + 1
                 {
-                    const double norm = (!same_loop_noise)
-                                            ? (imax * imax)
-                                            : (imax > 1 ? (imax * (imax - 1)) : 1.0);
+                    DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[i], p);
 
-                    int i = imax - 1;
+                    contract_D_half(qcl, qur, GdsG[r], half_lr_i);
+                    contract_D_half(qcr, qul, GdsG[s], half_rl_i);
+
                     for (int j = 0; j < i; j++)
                     {
-                        const auto &c1 =
-                            contract_D(half_lr[i + Neta * r], half_rl[j + Neta * s]);
-                        const auto &c2 =
-                            contract_D(half_lr[j + Neta * r], half_rl[i + Neta * s]);
+                        DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[j], p);
+                        contract_D_half(qcl, qur, GdsG[r], half_lr_j);
+                        contract_D_half(qcr, qul, GdsG[s], half_rl_j);
 
-                        // Symmetrize
-                        for (int t1 = 0; t1 < Nt; t1++)
-                        {
-                            for (int t2 = 0; t2 < Nt; t2++)
-                            {
-                                tmpSum[t1][t2] += c1[t1][t2] + c2[t1][t2];
-                            }
-                        }
+                        contract_D(half_lr_i, half_rl_j, tmpSum);
+                        contract_D(half_lr_j, half_rl_i, tmpSum);
                     }
                     if (!same_loop_noise)
                     {
-                        // Add diagonal term
-                        const auto &c_diag =
-                            contract_D(half_lr[i + Neta * r], half_rl[i + Neta * s]);
-                        for (int t1 = 0; t1 < Nt; t1++)
-                        {
-                            for (int t2 = 0; t2 < Nt; t2++)
-                            {
-                                tmpSum[t1][t2] += c_diag[t1][t2];
-                            }
-                        }
+                        // include diagonal term when loops use different noises
+                        contract_D(half_lr_i, half_rl_i, tmpSum);
                     }
+
+                    const double norm = (!same_loop_noise)
+                                            ? double((i + 1) * (i + 1))
+                                            : (i > 0 ? double((i + 1) * i) : 1.0);
+
                     for (int t1 = 0; t1 < Nt; t1++)
-                    {
                         for (int t2 = 0; t2 < Nt; t2++)
-                        {
                             tmpRes[t1][t2] = tmpSum[t1][t2] / norm;
-                        }
-                    }
-                    res.info.eta_max = std::to_string(imax);
-                    res.corr.clear();
+
+                    Result res;
+                    res.info.parity = (p == 0) ? "+" : "-";
+                    res.info.rr = std::to_string(r + 1) + std::to_string(s + 1);
+                    res.info.eta_max = std::to_string(i + 1);
                     res.corr = tmpRes;
                     result.push_back(res);
                 }

--- a/Hadrons/Modules/MContraction/DMixingTopD.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopD.hpp
@@ -252,9 +252,9 @@ void TDMixingTopD<FImpl>::execute(void)
 
     for (int p = 0; p < 2; p++)
     {
-        for (int r = 0; r < 2; ++r)
+        for (int r = 0; r < 2; r++)
         {
-            for (int s = 0; s < 2; ++s)
+            for (int s = 0; s < 2; s++)
             {
                 for (auto &row : tmpSum)
                     std::fill(row.begin(), row.end(), Complex(0.0));

--- a/Hadrons/Modules/MContraction/DMixingTopD.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopD.hpp
@@ -200,11 +200,11 @@ void TDMixingTopD<FImpl>::setup(void)
 
     GridCartesian *grid = envGetGrid(FermionField);
 
-    envTmpLat(PropagatorField, "half_lr_i");
-    envTmpLat(PropagatorField, "half_rl_i");
-    envTmpLat(PropagatorField, "half_lr_j");
-    envTmpLat(PropagatorField, "half_rl_j");
-    // envTmp(std::vector<PropagatorField>, "GdsG", 1, 2, PropagatorField(env().getGrid()));
+    const int Nt = env().getDim(Tdir);
+    envTmp(SlicedPropagator, "half_lr_i", 1, Nt);
+    envTmp(SlicedPropagator, "half_lr_j", 1, Nt);
+    envTmp(SlicedPropagator, "half_rl_i", 1, Nt);
+    envTmp(SlicedPropagator, "half_rl_j", 1, Nt);
     envTmpLat(PropagatorField, "GdsG");
 
     if (par().qLoop1 != par().qLoop2)
@@ -246,7 +246,6 @@ void TDMixingTopD<FImpl>::execute(void)
     envGetTmp(SlicedPropagator, half_rl_i);
     envGetTmp(SlicedPropagator, half_lr_j);
     envGetTmp(SlicedPropagator, half_rl_j);
-    // envGetTmp(std::vector<PropagatorField>, GdsG);
     envGetTmp(PropagatorField, GdsG);
 
     std::vector<std::vector<Complex>> tmpRes = std::vector<std::vector<Complex>>(Nt, std::vector<Complex>(Nt, 0.));

--- a/Hadrons/Modules/MContraction/DMixingTopD.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopD.hpp
@@ -112,16 +112,10 @@ public:
     // execution
     virtual void execute(void);
     // bespoke subcontractions
-    // virtual SlicedPropagator contract_D_half(const PropagatorField &prop_c,
-    //                                          const PropagatorField &prop_u,
-    //                                          const PropagatorField &loop);
     virtual void contract_D_half(const PropagatorField &prop_c,
                                  const PropagatorField &prop_u,
                                  const PropagatorField &loop,
                                  SlicedPropagator &out);
-
-    // virtual std::vector<std::vector<Complex>> contract_D(const SlicedPropagator &half_if,
-    //                                                      const SlicedPropagator &half_fi);
     virtual void contract_D(const SlicedPropagator &half_lr,
                            const SlicedPropagator &half_rl,
                            std::vector<std::vector<Complex>> &sum);

--- a/Hadrons/Modules/MContraction/DMixingUtils.hpp
+++ b/Hadrons/Modules/MContraction/DMixingUtils.hpp
@@ -47,6 +47,11 @@ public:
         std::vector<PropagatorField> &out,
         const PropagatorField &prop,
         const int p);
+    static void GH_cap(
+        PropagatorField &out,
+        const PropagatorField &prop,
+        const int p,
+        const int r);
 };
 
 template <typename FImpl>
@@ -81,6 +86,30 @@ void DMixingUtils<FImpl>::GH_cap(
     {
         out[0] += GH * prop * parityG[p] * GH;
         out[1] += spId * GH * trace(prop * parityG[p] * GH);
+    }
+};
+
+template <typename FImpl>
+void DMixingUtils<FImpl>::GH_cap(
+    typename DMixingUtils<FImpl>::PropagatorField &out,
+    const typename DMixingUtils<FImpl>::PropagatorField &prop,
+    const int p,
+    const int r)
+{
+    assert(r == 0 || r == 1);
+
+    SitePropagator spId(1.0);
+    out = Zero();
+
+    if (r == 0)
+    {
+        for (const auto &GH : GHs)
+            out += GH * prop * parityG[p] * GH;
+    }
+    else
+    {
+        for (const auto &GH : GHs)
+            out += spId * GH * trace(prop * parityG[p] * GH);
     }
 };
 


### PR DESCRIPTION
Some restructuring of contractions A, B, C and D:

### *diag A:*
- compute `half_l` and `half_r` only for needed `r` and `s`
- contraction done in single function `contract_A`

### *diag B*
- restructuring of if/else conditions
- introduction of lambda function for different traces

### *diag C*
- minimal change in `res.info`, now defined in innermost loop (also for other diagrams)

### *diag D*
- removed some unnecessary loops
- defined `contract_D` that already includes incremental sum