### PR TITLE
Feature/dmixing raoul

### DIFF
--- a/Hadrons/Modules/MContraction/DMixingTopA.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopA.hpp
@@ -92,7 +92,8 @@ public:
     {
     public:
         GRID_SERIALIZABLE_CLASS_MEMBERS(Metadata,
-                                        std::string, rr,
+                                        int        , r,
+                                        int        , s,
                                         std::string, parity);
     };
     typedef Correlator<Metadata, std::vector<Complex>> Result;
@@ -260,8 +261,9 @@ void TDMixingTopA<FImpl>::execute(void)
                 half_r = parityG[p] * GcuG_r[s];
 
                 Result res;
-                res.info.parity = (p == Parity::Pos) ? "+" : "-";
-                res.info.rr = std::to_string(r + 1) + std::to_string(s + 1);
+                res.info.parity = DMixingUtils<FImpl>::toString(p);
+                res.info.r      = DMixingUtils<FImpl>::toInt(r);
+                res.info.s      = DMixingUtils<FImpl>::toInt(s);
 
                 startTimer("contract_A");
                 res.corr = contract_A(half_l, half_r, pts, qin);

--- a/Hadrons/Modules/MContraction/DMixingTopA.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopA.hpp
@@ -242,8 +242,10 @@ void TDMixingTopA<FImpl>::execute(void)
     // parity +, parity -  (multiplying from left)
     const auto &GHpar = DMixingUtils<FImpl>::parityG;
 
+    startTimer("GH_cap");
     DMixingUtils<FImpl>::GH_cap(GcuG_l, qcul, 0);
     DMixingUtils<FImpl>::GH_cap(GcuG_r, qcur, 0);
+    stopTimer("GH_cap");
 
     for (int p = 0; p < 2; p++)
     {
@@ -259,7 +261,10 @@ void TDMixingTopA<FImpl>::execute(void)
                 res.info.parity = (p == 0) ? "+" : "-";
                 res.info.rr = std::to_string(r + 1) + std::to_string(s + 1);
 
+                startTimer("contract_A");
                 res.corr = contract_A(half_l, half_r, pts, qin);
+                stopTimer("contract_A");
+
                 result.push_back(res);
             }
         }

--- a/Hadrons/Modules/MContraction/DMixingTopA.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopA.hpp
@@ -97,6 +97,12 @@ public:
     };
     typedef Correlator<Metadata, std::vector<Complex>> Result;
 
+    using Parity   = typename DMixingUtils<FImpl>::Parity;
+    using OpStruct = typename DMixingUtils<FImpl>::OpStruct;
+
+    const std::array<Gamma,8> &GHs     = DMixingUtils<FImpl>::GHs;
+    const std::array<Gamma,2> &parityG = DMixingUtils<FImpl>::parityG;
+
 public:
     // constructor
     TDMixingTopA(const std::string name);
@@ -160,12 +166,12 @@ std::vector<std::string> TDMixingTopA<FImpl>::getOutputFiles(void)
 
 template <typename FImpl>
 std::vector<std::vector<Complex>> TDMixingTopA<FImpl>::contract_A(
-    const typename TDMixingTopA<FImpl>::PropagatorField &GcuG_l,
-    const typename TDMixingTopA<FImpl>::PropagatorField &GcuG_r,
+    const PropagatorField &GcuG_l,
+    const PropagatorField &GcuG_r,
     const std::vector<Coordinate *> &xs,
-    const std::vector<typename TDMixingTopA<FImpl>::PropagatorField *> &ds_prop_pt)
+    const std::vector<PropagatorField *> &ds_prop_pt)
 {
-    int Nt = GcuG_l.Grid()->_fdimensions[3];
+    int Nt = env().getDim(Tdir);
     Gamma g5(Gamma::Algebra::Gamma5);
     std::vector<std::vector<Complex>> corr(Nt, std::vector<Complex>(Nt));
 
@@ -239,26 +245,23 @@ void TDMixingTopA<FImpl>::execute(void)
     qcul = qcl * adj(qul) * g5; // qcl * g5 * (g5 * adj(qul) * g5)
     qcur = qcr * adj(qur) * g5; // qcr * g5 * (g5 * adj(qur) * g5)
 
-    // parity +, parity -  (multiplying from left)
-    const auto &GHpar = DMixingUtils<FImpl>::parityG;
-
     startTimer("GH_cap");
-    DMixingUtils<FImpl>::GH_cap(GcuG_l, qcul, 0);
-    DMixingUtils<FImpl>::GH_cap(GcuG_r, qcur, 0);
+    DMixingUtils<FImpl>::GH_cap(GcuG_l, qcul, Parity::Pos);
+    DMixingUtils<FImpl>::GH_cap(GcuG_r, qcur, Parity::Pos);
     stopTimer("GH_cap");
 
-    for (int p = 0; p < 2; p++)
+    for (const auto p : {Parity::Pos,Parity::Neg})
     {
-        for (int r = 0; r < 2; r++)
+        for (const auto r : {OpStruct::One,OpStruct::Two})
         {
-            half_l = GHpar[p] * GcuG_l[r];
+            half_l = parityG[p] * GcuG_l[r];
 
-            for (int s = 0; s < 2; s++)
+            for (const auto s : {OpStruct::One,OpStruct::Two})
             {
-                half_r = GHpar[p] * GcuG_r[s];
+                half_r = parityG[p] * GcuG_r[s];
 
                 Result res;
-                res.info.parity = (p == 0) ? "+" : "-";
+                res.info.parity = (p == Parity::Pos) ? "+" : "-";
                 res.info.rr = std::to_string(r + 1) + std::to_string(s + 1);
 
                 startTimer("contract_A");

--- a/Hadrons/Modules/MContraction/DMixingTopA.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopA.hpp
@@ -224,7 +224,6 @@ void TDMixingTopA<FImpl>::execute(void)
     std::vector<Result> result;
 
     const int Nt{env().getDim(Tdir)};
-    GridCartesian *grid = envGetGrid(FermionField);
 
     auto &qul = envGet(PropagatorField, par().qULeft);
     auto &qcl = envGet(PropagatorField, par().qCLeft);

--- a/Hadrons/Modules/MContraction/DMixingTopA.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopA.hpp
@@ -181,16 +181,24 @@ std::vector<std::vector<Complex>> TDMixingTopA<FImpl>::contract_A(
 
     for (int t1 = 0; t1 < Nt; t1++)
     {
+        startTimer("peekSite");
         const auto A = peekSite(GcuG_l, *xs[t1]);
+        stopTimer("peekSite");
 
+        startTimer("mult");
         const auto &ds = *ds_prop_pt[t1];
         const auto dsD = g5 * adj(ds) * g5;
-
         PropagatorField tmp = dsD * GcuG_r * ds;
-        sliceSum(tmp, B, Tp);
+        stopTimer("mult");
 
+        startTimer("sliceSum");
+        sliceSum(tmp, B, Tp);
+        stopTimer("sliceSum");
+
+        startTimer("trace");
         for (int t2 = 0; t2 < Nt; t2++)
             corr[t1][t2] = TensorRemove(trace(A * B[t2]));
+        stopTimer("trace");
     }
 
     return corr;
@@ -214,7 +222,7 @@ void TDMixingTopA<FImpl>::setup(void)
 template <typename FImpl>
 void TDMixingTopA<FImpl>::execute(void)
 {
-    LOG(Message) << "Computing D-meson mixing diagram, topology D" << std::endl;
+    LOG(Message) << "Computing D-meson mixing diagram, topology A" << std::endl;
     LOG(Message) << "qULeft  : " << par().qULeft << std::endl;
     LOG(Message) << "qCLeft  : " << par().qCLeft << std::endl;
     LOG(Message) << "qURight : " << par().qURight << std::endl;
@@ -265,9 +273,7 @@ void TDMixingTopA<FImpl>::execute(void)
                 res.info.r      = DMixingUtils<FImpl>::toInt(r);
                 res.info.s      = DMixingUtils<FImpl>::toInt(s);
 
-                startTimer("contract_A");
                 res.corr = contract_A(half_l, half_r, pts, qin);
-                stopTimer("contract_A");
 
                 result.push_back(res);
             }

--- a/Hadrons/Modules/MContraction/DMixingTopB.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopB.hpp
@@ -197,43 +197,6 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
 
     const bool same_r = (rR == rL);
 
-    // product of traces
-    auto tr_same = [&](const auto &trA, const auto &trB)
-    {
-        for (const auto &GH2 : GHs)
-        {
-            startTimer("trace");
-            LatticeComplex tmp = trace(trA * GH2) * trace(trB * parity * GH2);
-            stopTimer("trace");
-
-            startTimer("sliceSum");
-            sliceSum(tmp, buf, Tp);
-            stopTimer("sliceSum");
-
-            auto &row = corr[t1];
-            for (int t2 = 0; t2 < Nt; t2++)
-                row[t2] += TensorRemove(buf[t2]);
-        }
-    };
-    // trace of product
-    auto tr_diff = [&](const auto &trA, const auto &trB)
-    {
-        for (const auto &GH2 : GHs)
-        {
-            startTimer("trace");
-            LatticeComplex tmp = trace(trA * GH2 * trB * parity * GH2);
-            stopTimer("trace");
-
-            startTimer("sliceSum");
-            sliceSum(tmp, buf, Tp);
-            stopTimer("sliceSum");
-
-            auto &row = corr[t1];
-            for (int t2 = 0; t2 < Nt; t2++)
-                row[t2] += TensorRemove(buf[t2]);
-        }
-    };
-
     for (int t1 = 0; t1 < Nt; t1++)
     {
         const PropagatorField &ds = *ds_prop_pt[t1];
@@ -241,6 +204,44 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
 
         const PropagatorField cui = peekSite(ci, *xs[t1]) * adj(ui) * g5;
         const PropagatorField cuf = cf * adj(peekSite(uf, *xs[t1])) * g5;
+
+
+        // product of traces
+        auto tr_same = [&](const auto &trA, const auto &trB)
+        {
+            for (const auto &GH2 : GHs)
+            {
+                startTimer("trace");
+                LatticeComplex tmp = trace(trA * GH2) * trace(trB * parity * GH2);
+                stopTimer("trace");
+
+                startTimer("sliceSum");
+                sliceSum(tmp, buf, Tp);
+                stopTimer("sliceSum");
+
+                auto &row = corr[t1];
+                for (int t2 = 0; t2 < Nt; t2++)
+                    row[t2] += TensorRemove(buf[t2]);
+            }
+        };
+        // trace of product
+        auto tr_diff = [&](const auto &trA, const auto &trB)
+        {
+            for (const auto &GH2 : GHs)
+            {
+                startTimer("trace");
+                LatticeComplex tmp = trace(trA * GH2 * trB * parity * GH2);
+                stopTimer("trace");
+
+                startTimer("sliceSum");
+                sliceSum(tmp, buf, Tp);
+                stopTimer("sliceSum");
+
+                auto &row = corr[t1];
+                for (int t2 = 0; t2 < Nt; t2++)
+                    row[t2] += TensorRemove(buf[t2]);
+            }
+        };
 
         switch (rL)
         {

--- a/Hadrons/Modules/MContraction/DMixingTopB.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopB.hpp
@@ -196,6 +196,43 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
 
     const bool same_r = (rR == rL);
 
+    // product of traces
+    auto tr_same = [&](const auto &trA, const auto &trB)
+    {
+        for (const auto &GH2 : GHs)
+        {
+            startTimer("trace");
+            LatticeComplex tmp = trace(trA * GH2) * trace(trB * parity * GH2);
+            stopTimer("trace");
+
+            startTimer("sliceSum");
+            sliceSum(tmp, buf, Tp);
+            stopTimer("sliceSum");
+
+            auto &row = corr[t1];
+            for (int t2 = 0; t2 < Nt; t2++)
+                row[t2] += TensorRemove(buf[t2]);
+        }
+    };
+    // trace of product
+    auto tr_diff = [&](const auto &trA, const auto &trB)
+    {
+        for (const auto &GH2 : GHs)
+        {
+            startTimer("trace");
+            LatticeComplex tmp = trace(trA * GH2 * trB * parity * GH2);
+            stopTimer("trace");
+
+            startTimer("sliceSum");
+            sliceSum(tmp, buf, Tp);
+            stopTimer("sliceSum");
+
+            auto &row = corr[t1];
+            for (int t2 = 0; t2 < Nt; t2++)
+                row[t2] += TensorRemove(buf[t2]);
+        }
+    };
+
     for (int t1 = 0; t1 < Nt; t1++)
     {
         const PropagatorField &ds = *ds_prop_pt[t1];
@@ -203,43 +240,6 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
 
         const PropagatorField cui = peekSite(ci, *xs[t1]) * adj(ui) * g5;
         const PropagatorField cuf = cf * adj(peekSite(uf, *xs[t1])) * g5;
-
-        // product of traces
-        auto tr_same = [&](const auto &trA, const auto &trB)
-        {
-            for (const auto &GH2 : GHs)
-            {
-                startTimer("trace");
-                LatticeComplex tmp = trace(trA * GH2) * trace(trB * parity * GH2);
-                stopTimer("trace");
-
-                startTimer("sliceSum");
-                sliceSum(tmp, buf, Tp);
-                stopTimer("sliceSum");
-
-                auto &row = corr[t1];
-                for (int t2 = 0; t2 < Nt; t2++)
-                    row[t2] += TensorRemove(buf[t2]);
-            }
-        };
-        // trace of product
-        auto tr_diff = [&](const auto &trA, const auto &trB)
-        {
-            for (const auto &GH2 : GHs)
-            {
-                startTimer("trace");
-                LatticeComplex tmp = trace(trA * GH2 * trB * parity * GH2);
-                stopTimer("trace");
-
-                startTimer("sliceSum");
-                sliceSum(tmp, buf, Tp);
-                stopTimer("sliceSum");
-
-                auto &row = corr[t1];
-                for (int t2 = 0; t2 < Nt; t2++)
-                    row[t2] += TensorRemove(buf[t2]);
-            }
-        };
 
         switch (rL)
         {

--- a/Hadrons/Modules/MContraction/DMixingTopB.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopB.hpp
@@ -92,7 +92,8 @@ public:
     {
     public:
         GRID_SERIALIZABLE_CLASS_MEMBERS(Metadata,
-                                        std::string, rr,
+                                        int        , r,
+                                        int        , s,
                                         std::string, parity);
     };
     typedef Correlator<Metadata, std::vector<Complex>> Result;
@@ -308,8 +309,9 @@ void TDMixingTopB<FImpl>::execute(void)
             for (const auto s : {OpStruct::One,OpStruct::Two})
             {
                 Result res;
-                res.info.parity = (p == Parity::Pos) ? "+" : "-";
-                res.info.rr = std::to_string(r + 1) + std::to_string(s + 1);
+                res.info.parity = DMixingUtils<FImpl>::toString(p);
+                res.info.r      = DMixingUtils<FImpl>::toInt(r);
+                res.info.s      = DMixingUtils<FImpl>::toInt(s);
 
                 res.corr = contract_B(qcl, qul, qcr, qur, qin, pts, p, r, s);
                 result.push_back(res);

--- a/Hadrons/Modules/MContraction/DMixingTopB.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopB.hpp
@@ -205,8 +205,14 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
         {
             for (const auto &GH2 : GHs)
             {
+                startTimer("trace");
                 LatticeComplex tmp = trace(trA * GH2) * trace(trB * parity * GH2);
+                stopTimer("trace");
+
+                startTimer("sliceSum");
                 sliceSum(tmp, buf, Tp);
+                stopTimer("sliceSum");
+
                 auto &row = corr[t1];
                 for (int t2 = 0; t2 < Nt; t2++)
                     row[t2] += TensorRemove(buf[t2]);
@@ -217,8 +223,14 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
         {
             for (const auto &GH2 : GHs)
             {
+                startTimer("trace");
                 LatticeComplex tmp = trace(trA * GH2 * trB * parity * GH2);
+                stopTimer("trace");
+
+                startTimer("sliceSum");
                 sliceSum(tmp, buf, Tp);
+                stopTimer("sliceSum");
+
                 auto &row = corr[t1];
                 for (int t2 = 0; t2 < Nt; t2++)
                     row[t2] += TensorRemove(buf[t2]);
@@ -229,8 +241,10 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
         {
             for (const auto &GH1 : GHs)
             {
+                startTimer("trA & trB");
                 PropagatorField trA = ds * parity * GH1 * cui;
                 PropagatorField trB = cuf * GH1 * dsD;
+                stopTimer("trA & trB");
                 same_r ? tr_same(trA, trB) : tr_diff(trA, trB);
             }
         }
@@ -238,8 +252,10 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
         {
             for (const auto &GH1 : GHs)
             {
+                startTimer("trA & trB");
                 PropagatorField trA = cuf * GH1 * cui;
                 PropagatorField trB = ds * parity * GH1 * dsD;
+                stopTimer("trA & trB");
                 same_r ? tr_same(trA, trB) : tr_diff(trA, trB);
             }
         }

--- a/Hadrons/Modules/MContraction/DMixingTopB.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopB.hpp
@@ -97,6 +97,12 @@ public:
     };
     typedef Correlator<Metadata, std::vector<Complex>> Result;
 
+    using Parity   = typename DMixingUtils<FImpl>::Parity;
+    using OpStruct = typename DMixingUtils<FImpl>::OpStruct;
+
+    const std::array<Gamma,8> &GHs     = DMixingUtils<FImpl>::GHs;
+    const std::array<Gamma,2> &parityG = DMixingUtils<FImpl>::parityG;
+
 public:
     // constructor
     TDMixingTopB(const std::string name);
@@ -118,9 +124,9 @@ public:
         const PropagatorField &uf,
         const std::vector<PropagatorField *> &ds_prop_pt,
         const std::vector<Coordinate *> &xs,
-        const int p,
-        const int rL,
-        const int rR);
+        const Parity p,
+        const OpStruct rL,
+        const OpStruct rR);
 };
 
 MODULE_REGISTER_TMP(DMixingTopB, TDMixingTopB<FIMPL>, MContraction);
@@ -169,26 +175,24 @@ std::vector<std::string> TDMixingTopB<FImpl>::getOutputFiles(void)
 
 template <typename FImpl>
 std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
-    const TDMixingTopB<FImpl>::PropagatorField &ci,
-    const TDMixingTopB<FImpl>::PropagatorField &ui,
-    const TDMixingTopB<FImpl>::PropagatorField &cf,
-    const TDMixingTopB<FImpl>::PropagatorField &uf,
-    const std::vector<typename TDMixingTopB<FImpl>::PropagatorField *> &ds_prop_pt,
+    const PropagatorField &ci,
+    const PropagatorField &ui,
+    const PropagatorField &cf,
+    const PropagatorField &uf,
+    const std::vector<PropagatorField *> &ds_prop_pt,
     const std::vector<Coordinate *> &xs,
-    const int p,
-    const int rL,
-    const int rR)
+    const Parity p,
+    const OpStruct rL,
+    const OpStruct rR)
 {
-    int Nt = ci.Grid()->_fdimensions[3];
+    int Nt = env().getDim(Tdir);
     Gamma g5(Gamma::Algebra::Gamma5);
 
     std::vector<std::vector<Complex>> corr(Nt, std::vector<Complex>(Nt, 0.));
     std::vector<TComplex> buf;
     buf.reserve(Nt);
 
-    const auto &GHs = DMixingUtils<FImpl>::GHs;
-    const auto &GHpar = DMixingUtils<FImpl>::parityG;
-    const Gamma parity = GHpar[p];
+    const Gamma parity = parityG[p];
 
     const bool same_r = (rR == rL);
 
@@ -237,27 +241,32 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
             }
         };
 
-        if (rL == 0)
+        switch (rL)
         {
-            for (const auto &GH1 : GHs)
-            {
-                startTimer("trA & trB");
-                PropagatorField trA = ds * parity * GH1 * cui;
-                PropagatorField trB = cuf * GH1 * dsD;
-                stopTimer("trA & trB");
-                same_r ? tr_same(trA, trB) : tr_diff(trA, trB);
-            }
-        }
-        else
-        {
-            for (const auto &GH1 : GHs)
-            {
-                startTimer("trA & trB");
-                PropagatorField trA = cuf * GH1 * cui;
-                PropagatorField trB = ds * parity * GH1 * dsD;
-                stopTimer("trA & trB");
-                same_r ? tr_same(trA, trB) : tr_diff(trA, trB);
-            }
+            case OpStruct::One:
+                for (const auto &GH1 : GHs)
+                {
+                    startTimer("trA & trB");
+                    PropagatorField trA = ds * parity * GH1 * cui;
+                    PropagatorField trB = cuf * GH1 * dsD;
+                    stopTimer("trA & trB");
+                    same_r ? tr_same(trA, trB) : tr_diff(trA, trB);
+                }
+                break;
+
+            case OpStruct::Two:
+                for (const auto &GH1 : GHs)
+                {
+                    startTimer("trA & trB");
+                    PropagatorField trA = cuf * GH1 * cui;
+                    PropagatorField trB = ds * parity * GH1 * dsD;
+                    stopTimer("trA & trB");
+                    same_r ? tr_same(trA, trB) : tr_diff(trA, trB);
+                }
+                break;
+
+            default:
+                HADRONS_ERROR(Argument, "DMixingTopB: Invalid RS value");
         }
     }
 
@@ -292,14 +301,14 @@ void TDMixingTopB<FImpl>::execute(void)
     auto &qin = envGet(std::vector<PropagatorField *>, par().qInt);
     auto &pts = envGet(std::vector<Coordinate *>, par().points);
 
-    for (int p = 0; p < 2; p++)
+    for (const auto p : {Parity::Pos,Parity::Neg})
     {
-        for (int r = 0; r < 2; r++)
+        for (const auto r : {OpStruct::One,OpStruct::Two})
         {
-            for (int s = 0; s < 2; s++)
+            for (const auto s : {OpStruct::One,OpStruct::Two})
             {
                 Result res;
-                res.info.parity = (p == 0) ? "+" : "-";
+                res.info.parity = (p == Parity::Pos) ? "+" : "-";
                 res.info.rr = std::to_string(r + 1) + std::to_string(s + 1);
 
                 res.corr = contract_B(qcl, qul, qcr, qur, qin, pts, p, r, s);

--- a/Hadrons/Modules/MContraction/DMixingTopB.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopB.hpp
@@ -212,9 +212,9 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
         {
             for (const auto &GH2 : GHs)
             {
-                startTimer("trace");
+                startTimer("2 trace");
                 LatticeComplex tmp = trace(trA * GH2) * trace(trB * parity * GH2);
-                stopTimer("trace");
+                stopTimer("2 trace");
 
                 startTimer("sliceSum");
                 sliceSum(tmp, buf, Tp);
@@ -230,9 +230,9 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
         {
             for (const auto &GH2 : GHs)
             {
-                startTimer("trace");
+                startTimer("1 trace");
                 LatticeComplex tmp = trace(trA * GH2 * trB * parity * GH2);
-                stopTimer("trace");
+                stopTimer("1 trace");
 
                 startTimer("sliceSum");
                 sliceSum(tmp, buf, Tp);

--- a/Hadrons/Modules/MContraction/DMixingTopB.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopB.hpp
@@ -266,7 +266,7 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
                 break;
 
             default:
-                HADRONS_ERROR(Argument, "DMixingTopB: Invalid RS value");
+                HADRONS_ERROR(Argument, "DMixingTopB: Invalid OpStruct value");
         }
     }
 

--- a/Hadrons/Modules/MContraction/DMixingTopB.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopB.hpp
@@ -199,12 +199,13 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
 
     for (int t1 = 0; t1 < Nt; t1++)
     {
+        startTimer("mult");
         const PropagatorField &ds = *ds_prop_pt[t1];
         const PropagatorField dsD = g5 * adj(ds) * g5;
 
         const PropagatorField cui = peekSite(ci, *xs[t1]) * adj(ui) * g5;
         const PropagatorField cuf = cf * adj(peekSite(uf, *xs[t1])) * g5;
-
+        stopTimer("mult");
 
         // product of traces
         auto tr_same = [&](const auto &trA, const auto &trB)
@@ -248,10 +249,10 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
             case OpStruct::One:
                 for (const auto &GH1 : GHs)
                 {
-                    startTimer("trA & trB");
+                    startTimer("mult");
                     PropagatorField trA = ds * parity * GH1 * cui;
                     PropagatorField trB = cuf * GH1 * dsD;
-                    stopTimer("trA & trB");
+                    stopTimer("mult");
                     same_r ? tr_same(trA, trB) : tr_diff(trA, trB);
                 }
                 break;
@@ -259,10 +260,10 @@ std::vector<std::vector<Complex>> TDMixingTopB<FImpl>::contract_B(
             case OpStruct::Two:
                 for (const auto &GH1 : GHs)
                 {
-                    startTimer("trA & trB");
+                    startTimer("mult");
                     PropagatorField trA = cuf * GH1 * cui;
                     PropagatorField trB = ds * parity * GH1 * dsD;
-                    stopTimer("trA & trB");
+                    stopTimer("mult");
                     same_r ? tr_same(trA, trB) : tr_diff(trA, trB);
                 }
                 break;

--- a/Hadrons/Modules/MContraction/DMixingTopC.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopC.hpp
@@ -85,9 +85,10 @@ public:
     {
     public:
         GRID_SERIALIZABLE_CLASS_MEMBERS(Metadata,
-                                        std::string, r,
+                                        int        , r,
+                                        int        , s,
                                         std::string, parity,
-                                        std::string, eta);
+                                        int        , eta);
     };
     typedef Correlator<Metadata, Complex> Result;
 
@@ -231,9 +232,9 @@ void TDMixingTopC<FImpl>::execute(void)
             for (const auto r : {OpStruct::One,OpStruct::Two})
             {
                 Result res;
-                res.info.parity = (p == Parity::Pos) ? "+" : "-";
-                res.info.eta = std::to_string(i);
-                res.info.r = std::to_string(r + 1);
+                res.info.parity = DMixingUtils<FImpl>::toString(p);
+                res.info.r      = DMixingUtils<FImpl>::toInt(r);
+                res.info.eta    = i;
 
                 res.corr = contract_C_half(qcl, qul_adj, GdsG[r]);
                 result.push_back(res);

--- a/Hadrons/Modules/MContraction/DMixingTopC.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopC.hpp
@@ -86,7 +86,6 @@ public:
     public:
         GRID_SERIALIZABLE_CLASS_MEMBERS(Metadata,
                                         int        , r,
-                                        int        , s,
                                         std::string, parity,
                                         int        , eta);
     };

--- a/Hadrons/Modules/MContraction/DMixingTopC.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopC.hpp
@@ -91,6 +91,12 @@ public:
     };
     typedef Correlator<Metadata, Complex> Result;
 
+    using Parity   = typename DMixingUtils<FImpl>::Parity;
+    using OpStruct = typename DMixingUtils<FImpl>::OpStruct;
+
+    const std::array<Gamma,8> &GHs     = DMixingUtils<FImpl>::GHs;
+    const std::array<Gamma,2> &parityG = DMixingUtils<FImpl>::parityG;
+
 public:
     // constructor
     TDMixingTopC(const std::string name);
@@ -155,9 +161,9 @@ std::vector<std::string> TDMixingTopC<FImpl>::getOutputFiles(void)
 
 template <typename FImpl>
 std::vector<Complex> TDMixingTopC<FImpl>::contract_C_half(
-    const TDMixingTopC<FImpl>::PropagatorField &prop_c,
-    const TDMixingTopC<FImpl>::PropagatorField &prop_u_adj,
-    const TDMixingTopC<FImpl>::PropagatorField &loop)
+    const PropagatorField &prop_c,
+    const PropagatorField &prop_u_adj,
+    const PropagatorField &loop)
 {
     Gamma g5(Gamma::Algebra::Gamma5);
 
@@ -209,19 +215,18 @@ void TDMixingTopC<FImpl>::execute(void)
 
     envGetTmp(std::vector<PropagatorField>, GdsG);
 
-    for (int p = 0; p < 2; p++)
+    for (const auto p : {Parity::Pos,Parity::Neg})
     {
         for (int i = 0; i < Neta; i++)
         {
-            // here one has to add ql2 if one wants them to be allowed to be different
             startTimer("GH_cap");
             DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[i], p);
             stopTimer("GH_cap");
 
-            for (int r = 0; r < 2; r++)
+            for (const auto r : {OpStruct::One,OpStruct::Two})
             {
                 Result res;
-                res.info.parity = (p == 0) ? "+" : "-";
+                res.info.parity = (p == Parity::Pos) ? "+" : "-";
                 res.info.eta = std::to_string(i);
                 res.info.r = std::to_string(r + 1);
 

--- a/Hadrons/Modules/MContraction/DMixingTopC.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopC.hpp
@@ -214,7 +214,9 @@ void TDMixingTopC<FImpl>::execute(void)
         for (int i = 0; i < Neta; i++)
         {
             // here one has to add ql2 if one wants them to be allowed to be different
+            startTimer("GH_cap");
             DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[i], p);
+            stopTimer("GH_cap");
 
             for (int r = 0; r < 2; r++)
             {
@@ -223,7 +225,9 @@ void TDMixingTopC<FImpl>::execute(void)
                 res.info.eta = std::to_string(i);
                 res.info.r = std::to_string(r + 1);
 
+                startTimer("contract_C_half");
                 res.corr = contract_C_half(qcl, qul_adj, GdsG[r]);
+                stopTimer("contract_C_half");
                 result.push_back(res);
             }
         }

--- a/Hadrons/Modules/MContraction/DMixingTopC.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopC.hpp
@@ -167,9 +167,14 @@ std::vector<Complex> TDMixingTopC<FImpl>::contract_C_half(
 {
     Gamma g5(Gamma::Algebra::Gamma5);
 
+    startTimer("trace");
     LatticeComplex tmp = trace(prop_c * g5 * prop_u_adj * loop);
+    stopTimer("trace");
+
+    startTimer("sliceSum");
     SlicedComplex ret;
     sliceSum(tmp, ret, Tp);
+    stopTimer("sliceSum");
 
     const int Nt{env().getDim(Tdir)};
     std::vector<Complex> out(Nt);
@@ -230,9 +235,7 @@ void TDMixingTopC<FImpl>::execute(void)
                 res.info.eta = std::to_string(i);
                 res.info.r = std::to_string(r + 1);
 
-                startTimer("contract_C_half");
                 res.corr = contract_C_half(qcl, qul_adj, GdsG[r]);
-                stopTimer("contract_C_half");
                 result.push_back(res);
             }
         }

--- a/Hadrons/Modules/MContraction/DMixingTopD.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopD.hpp
@@ -268,11 +268,15 @@ void TDMixingTopD<FImpl>::execute(void)
         for (int i = 0; i < Neta; i++)
         {
             // here one has to add ql2 if one wants them to be allowed to be different
+            startTimer("GH_cap");
             DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[i], p);
+            stopTimer("GH_cap");
             for (int r = 0; r < 2; r++)
             {
+                startTimer("contract_D_half");
                 half_l[i + Neta * r] = contract_D_half(qcl, qur_adj, GdsG[r]);
                 half_r[i + Neta * r] = contract_D_half(qcr, qul_adj, GdsG[r]);
+                stopTimer("contract_D_half");
             }
         }
 
@@ -299,12 +303,16 @@ void TDMixingTopD<FImpl>::execute(void)
                         Lsum[t] += Li[t];
                         Rsum[t] += Ri[t];
                     }
+                    startTimer("contract_D");
                     tmpSum = contract_D(Lsum, Rsum);
+                    stopTimer("contract_D");
 
                     if (same_loop_noise)
                     {
                         // accumulate sum of diagonal terms & remove from total
+                        startTimer("contract_D");
                         const auto &diag = contract_D(Li, Ri);
+                        stopTimer("contract_D");
                         for (int t1 = 0; t1 < Nt; t1++)
                             for (int t2 = 0; t2 < Nt; t2++)
                             {

--- a/Hadrons/Modules/MContraction/DMixingTopD.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopD.hpp
@@ -98,6 +98,12 @@ public:
     };
     typedef Correlator<Metadata, std::vector<Complex>> Result;
 
+    using Parity   = typename DMixingUtils<FImpl>::Parity;
+    using OpStruct = typename DMixingUtils<FImpl>::OpStruct;
+
+    const std::array<Gamma,8> &GHs     = DMixingUtils<FImpl>::GHs;
+    const std::array<Gamma,2> &parityG = DMixingUtils<FImpl>::parityG;
+
 public:
     // constructor
     TDMixingTopD(const std::string name);
@@ -119,6 +125,10 @@ public:
     virtual std::vector<std::vector<Complex>> contract_D(
         const SlicedPropagator &half_if,
         const SlicedPropagator &half_fi);
+
+    int half_idx(OpStruct r, int i, int Neta) {
+        return i + Neta * r;
+    }
 };
 
 MODULE_REGISTER_TMP(DMixingTopD, TDMixingTopD<FIMPL>, MContraction);
@@ -168,9 +178,9 @@ std::vector<std::string> TDMixingTopD<FImpl>::getOutputFiles(void)
 
 template <typename FImpl>
 typename TDMixingTopD<FImpl>::SlicedPropagator TDMixingTopD<FImpl>::contract_D_half(
-    const TDMixingTopD<FImpl>::PropagatorField &prop_c,
-    const TDMixingTopD<FImpl>::PropagatorField &prop_u_adj,
-    const TDMixingTopD<FImpl>::PropagatorField &loop)
+    const PropagatorField &prop_c,
+    const PropagatorField &prop_u_adj,
+    const PropagatorField &loop)
 {
     PropagatorField tmp = prop_u_adj * loop * prop_c;
     SlicedPropagator out;
@@ -180,12 +190,12 @@ typename TDMixingTopD<FImpl>::SlicedPropagator TDMixingTopD<FImpl>::contract_D_h
 
 template <typename FImpl>
 std::vector<std::vector<Complex>> TDMixingTopD<FImpl>::contract_D(
-    const typename TDMixingTopD<FImpl>::SlicedPropagator &half_l,
-    const typename TDMixingTopD<FImpl>::SlicedPropagator &half_r)
+    const SlicedPropagator &half_l,
+    const SlicedPropagator &half_r)
 {
     Gamma g5(Gamma::Algebra::Gamma5);
 
-    int Nt = half_l.size();
+    int Nt = env().getDim(Tdir);
     std::vector<std::vector<Complex>> corr(Nt, std::vector<Complex>(Nt));
 
     for (int t1 = 0; t1 < Nt; t1++)
@@ -236,7 +246,6 @@ void TDMixingTopD<FImpl>::execute(void)
     std::vector<Result> result;
 
     const int Nt{env().getDim(Tdir)};
-    GridCartesian *grid = envGetGrid(FermionField);
 
     auto &qul = envGet(PropagatorField, par().qULeft);
     auto &qcl = envGet(PropagatorField, par().qCLeft);
@@ -263,7 +272,7 @@ void TDMixingTopD<FImpl>::execute(void)
 
     SlicedPropagator Lsum(Nt), Rsum(Nt);
 
-    for (int p = 0; p < 2; p++)
+    for (const auto p : {Parity::Pos,Parity::Neg})
     {
         for (int i = 0; i < Neta; i++)
         {
@@ -271,18 +280,18 @@ void TDMixingTopD<FImpl>::execute(void)
             startTimer("GH_cap");
             DMixingUtils<FImpl>::GH_cap(GdsG, *ql1[i], p);
             stopTimer("GH_cap");
-            for (int r = 0; r < 2; r++)
+            for (const auto r : {OpStruct::One,OpStruct::Two})
             {
                 startTimer("contract_D_half");
-                half_l[i + Neta * r] = contract_D_half(qcl, qur_adj, GdsG[r]);
-                half_r[i + Neta * r] = contract_D_half(qcr, qul_adj, GdsG[r]);
+                half_l[half_idx(r,i,Neta)] = contract_D_half(qcl, qur_adj, GdsG[r]);
+                half_r[half_idx(r,i,Neta)] = contract_D_half(qcr, qul_adj, GdsG[r]);
                 stopTimer("contract_D_half");
             }
         }
 
-        for (int r = 0; r < 2; r++)
+        for (const auto r : {OpStruct::One,OpStruct::Two})
         {
-            for (int s = 0; s < 2; s++)
+            for (const auto s : {OpStruct::One,OpStruct::Two})
             {
                 for (int t = 0; t < Nt; t++)
                 {
@@ -294,8 +303,8 @@ void TDMixingTopD<FImpl>::execute(void)
 
                 for (int i = 0; i < Neta; i++) // imax = i + 1
                 {
-                    const auto &Li = half_l[i + Neta * r];
-                    const auto &Ri = half_r[i + Neta * s];
+                    const auto &Li = half_l[half_idx(r,i,Neta)];
+                    const auto &Ri = half_r[half_idx(s,i,Neta)];
 
                     // accumulate sums of Li, Ri
                     for (int t = 0; t < Nt; t++)
@@ -330,7 +339,7 @@ void TDMixingTopD<FImpl>::execute(void)
                             tmpRes[t1][t2] = tmpSum[t1][t2] / norm;
 
                     Result res;
-                    res.info.parity = (p == 0) ? "+" : "-";
+                    res.info.parity = (p == Parity::Pos) ? "+" : "-";
                     res.info.rr = std::to_string(r + 1) + std::to_string(s + 1);
                     res.info.eta_max = std::to_string(i + 1);
                     res.corr = tmpRes;

--- a/Hadrons/Modules/MContraction/DMixingTopD.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopD.hpp
@@ -320,7 +320,7 @@ void TDMixingTopD<FImpl>::execute(void)
                     {
                         // accumulate sum of diagonal terms & remove from total
                         startTimer("contract_D");
-                        const auto &diag = contract_D(Li, Ri);
+                        const auto diag = contract_D(Li, Ri);
                         stopTimer("contract_D");
                         for (int t1 = 0; t1 < Nt; t1++)
                             for (int t2 = 0; t2 < Nt; t2++)

--- a/Hadrons/Modules/MContraction/DMixingTopD.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopD.hpp
@@ -183,9 +183,14 @@ typename TDMixingTopD<FImpl>::SlicedPropagator TDMixingTopD<FImpl>::contract_D_h
     const PropagatorField &prop_u_adj,
     const PropagatorField &loop)
 {
+    startTimer("mult");
     PropagatorField tmp = prop_u_adj * loop * prop_c;
+    stopTimer("mult");
+
     SlicedPropagator out;
+    startTimer("sliceSum");
     sliceSum(tmp, out, Tp);
+    stopTimer("sliceSum");
     return out;
 };
 
@@ -199,6 +204,7 @@ std::vector<std::vector<Complex>> TDMixingTopD<FImpl>::contract_D(
     int Nt = env().getDim(Tdir);
     std::vector<std::vector<Complex>> corr(Nt, std::vector<Complex>(Nt));
 
+    startTimer("trace");
     for (int t1 = 0; t1 < Nt; t1++)
     {
         for (int t2 = 0; t2 < Nt; t2++)
@@ -206,6 +212,7 @@ std::vector<std::vector<Complex>> TDMixingTopD<FImpl>::contract_D(
             corr[t1][t2] = TensorRemove(trace(half_l[t1] * g5 * half_r[t2] * g5));
         }
     }
+    stopTimer("trace");
 
     return corr;
 };
@@ -283,10 +290,8 @@ void TDMixingTopD<FImpl>::execute(void)
             stopTimer("GH_cap");
             for (const auto r : {OpStruct::One,OpStruct::Two})
             {
-                startTimer("contract_D_half");
                 half_l[half_idx(r,i,Neta)] = contract_D_half(qcl, qur_adj, GdsG[r]);
                 half_r[half_idx(r,i,Neta)] = contract_D_half(qcr, qul_adj, GdsG[r]);
-                stopTimer("contract_D_half");
             }
         }
 
@@ -315,16 +320,12 @@ void TDMixingTopD<FImpl>::execute(void)
                         Lsum[t] += Li[t];
                         Rsum[t] += Ri[t];
                     }
-                    startTimer("contract_D");
                     tmpSum = contract_D(Lsum, Rsum);
-                    stopTimer("contract_D");
 
                     if (same_loop_noise)
                     {
                         // accumulate sum of diagonal terms & remove from total
-                        startTimer("contract_D");
                         const auto diag = contract_D(Li, Ri);
-                        stopTimer("contract_D");
                         for (int t1 = 0; t1 < Nt; t1++)
                             for (int t2 = 0; t2 < Nt; t2++)
                             {

--- a/Hadrons/Modules/MContraction/DMixingTopD.hpp
+++ b/Hadrons/Modules/MContraction/DMixingTopD.hpp
@@ -92,9 +92,10 @@ public:
     {
     public:
         GRID_SERIALIZABLE_CLASS_MEMBERS(Metadata,
-                                        std::string, rr,
+                                        int        , r,
+                                        int        , s,
                                         std::string, parity,
-                                        std::string, eta_max);
+                                        int        , eta_max);
     };
     typedef Correlator<Metadata, std::vector<Complex>> Result;
 
@@ -301,8 +302,10 @@ void TDMixingTopD<FImpl>::execute(void)
                         std::fill(diagSum[t].begin(), diagSum[t].end(), Complex(0.0));
                 }
 
-                for (int i = 0; i < Neta; i++) // imax = i + 1
+                for (int i = 0; i < Neta; i++)
                 {
+                    int eta_max = i + 1;
+
                     const auto &Li = half_l[half_idx(r,i,Neta)];
                     const auto &Ri = half_r[half_idx(s,i,Neta)];
 
@@ -339,9 +342,11 @@ void TDMixingTopD<FImpl>::execute(void)
                             tmpRes[t1][t2] = tmpSum[t1][t2] / norm;
 
                     Result res;
-                    res.info.parity = (p == Parity::Pos) ? "+" : "-";
-                    res.info.rr = std::to_string(r + 1) + std::to_string(s + 1);
-                    res.info.eta_max = std::to_string(i + 1);
+                    res.info.parity  = DMixingUtils<FImpl>::toString(p);
+                    res.info.r       = DMixingUtils<FImpl>::toInt(r);
+                    res.info.s       = DMixingUtils<FImpl>::toInt(s);
+                    res.info.eta_max = eta_max;
+                    
                     res.corr = tmpRes;
                     result.push_back(res);
                 }

--- a/Hadrons/Modules/MContraction/DMixingUtils.hpp
+++ b/Hadrons/Modules/MContraction/DMixingUtils.hpp
@@ -54,10 +54,13 @@ public:
         One=0,
         Two=1
     };
+    static int toInt(OpStruct r);
     enum Parity {
         Pos=0,
         Neg=1
     };
+    static std::string toString(Parity p);
+
     static const std::array<Gamma, 8> GHs;
     static const std::array<Gamma, 2> parityG;
     static void GH_cap(
@@ -70,6 +73,17 @@ public:
         const Parity p,
         const OpStruct r);
 };
+
+
+template <typename FImpl>
+int DMixingUtils<FImpl>::toInt(OpStruct r) {
+    if (r == OpStruct::One)
+        return 1;
+    else if (r == OpStruct::Two)
+        return 2;
+    else
+        HADRONS_ERROR(Argument, "DMixingUtils: Invalid OpStruct value");
+}
 
 template <typename FImpl>
 const std::array<Gamma, 8> DMixingUtils<FImpl>::GHs = {
@@ -88,6 +102,17 @@ const std::array<Gamma, 2> DMixingUtils<FImpl>::parityG = {
     Gamma(Gamma::Algebra::Identity),
     Gamma(Gamma::Algebra::Gamma5)
 };
+
+template <typename FImpl>
+std::string DMixingUtils<FImpl>::toString(Parity p) {
+    if (p == Parity::Pos)
+        return "+";
+    else if (p == Parity::Neg)
+        return "-";
+    else
+        HADRONS_ERROR(Argument, "DMixingUtils: Invalid Parity value");
+}
+
 
 template <typename FImpl>
 void DMixingUtils<FImpl>::GH_cap(

--- a/Hadrons/Modules/MContraction/DMixingUtils.hpp
+++ b/Hadrons/Modules/MContraction/DMixingUtils.hpp
@@ -41,17 +41,34 @@ class DMixingUtils
 {
 public:
     FERM_TYPE_ALIASES(FImpl, );
+    /*     OpStruct
+     * \   /      \    /
+     *  \ /        \  /
+     *   *          **
+     *   *         /  \
+     *  / \       /    \
+     * /   \    
+     *  One        Two
+    */
+    enum OpStruct {
+        One=0,
+        Two=1
+    };
+    enum Parity {
+        Pos=0,
+        Neg=1
+    };
     static const std::array<Gamma, 8> GHs;
     static const std::array<Gamma, 2> parityG;
     static void GH_cap(
         std::vector<PropagatorField> &out,
         const PropagatorField &prop,
-        const int p);
+        const Parity p);
     static void GH_cap(
         PropagatorField &out,
         const PropagatorField &prop,
-        const int p,
-        const int r);
+        const Parity p,
+        const OpStruct r);
 };
 
 template <typename FImpl>
@@ -63,53 +80,58 @@ const std::array<Gamma, 8> DMixingUtils<FImpl>::GHs = {
     Gamma(Gamma::Algebra::GammaXGamma5),
     Gamma(Gamma::Algebra::GammaYGamma5),
     Gamma(Gamma::Algebra::GammaZGamma5),
-    Gamma(Gamma::Algebra::GammaTGamma5)};
+    Gamma(Gamma::Algebra::GammaTGamma5)
+};
 
 template <typename FImpl>
 const std::array<Gamma, 2> DMixingUtils<FImpl>::parityG = {
     Gamma(Gamma::Algebra::Identity),
-    Gamma(Gamma::Algebra::Gamma5)};
+    Gamma(Gamma::Algebra::Gamma5)
+};
 
 template <typename FImpl>
 void DMixingUtils<FImpl>::GH_cap(
-    std::vector<typename DMixingUtils<FImpl>::PropagatorField> &out,
-    const typename DMixingUtils<FImpl>::PropagatorField &prop,
-    const int p)
+    std::vector<PropagatorField> &out,
+    const PropagatorField &prop,
+    const Parity p)
 {
     assert(out.size() == 2);
 
     SitePropagator spId(1.0);
-    out[0] = Zero();
-    out[1] = Zero();
+    out[OpStruct::One] = Zero();
+    out[OpStruct::Two] = Zero();
 
     for (const auto &GH : GHs)
     {
-        out[0] += GH * prop * parityG[p] * GH;
-        out[1] += spId * GH * trace(prop * parityG[p] * GH);
+        out[OpStruct::One] += GH * prop * parityG[p] * GH;
+        out[OpStruct::Two] += spId * GH * trace(prop * parityG[p] * GH);
     }
 };
 
 template <typename FImpl>
 void DMixingUtils<FImpl>::GH_cap(
-    typename DMixingUtils<FImpl>::PropagatorField &out,
-    const typename DMixingUtils<FImpl>::PropagatorField &prop,
-    const int p,
-    const int r)
+    PropagatorField &out,
+    const PropagatorField &prop,
+    const Parity p,
+    const OpStruct r)
 {
-    assert(r == 0 || r == 1);
-
     SitePropagator spId(1.0);
     out = Zero();
 
-    if (r == 0)
+    switch (r)
     {
-        for (const auto &GH : GHs)
-            out += GH * prop * parityG[p] * GH;
-    }
-    else
-    {
-        for (const auto &GH : GHs)
-            out += spId * GH * trace(prop * parityG[p] * GH);
+        case OpStruct::One:
+            for (const auto &GH : GHs)
+                out += GH * prop * parityG[p] * GH;
+            break;
+
+        case OpStruct::Two:
+            for (const auto &GH : GHs)
+                out += spId * GH * trace(prop * parityG[p] * GH);
+            break;
+
+        default:
+            HADRONS_ERROR(Argument, "DMixingUtils: Invalid RS value");
     }
 };
 

--- a/Hadrons/Modules/MContraction/DMixingUtils.hpp
+++ b/Hadrons/Modules/MContraction/DMixingUtils.hpp
@@ -131,7 +131,7 @@ void DMixingUtils<FImpl>::GH_cap(
             break;
 
         default:
-            HADRONS_ERROR(Argument, "DMixingUtils: Invalid RS value");
+            HADRONS_ERROR(Argument, "DMixingUtils: Invalid OpStruct value");
     }
 };
 

--- a/Hadrons/Modules/MContraction/DMixingUtils.hpp
+++ b/Hadrons/Modules/MContraction/DMixingUtils.hpp
@@ -42,13 +42,15 @@ class DMixingUtils
 public:
     FERM_TYPE_ALIASES(FImpl, );
     /*     OpStruct
-     * \   /      \    /
-     *  \ /        \  /
-     *   *          **
-     *   *         /  \
-     *  / \       /    \
-     * /   \    
-     *  One        Two
+     * c     q    c      q
+     *  \   /      \    /
+     *   \ /        \  /
+     *    *          **
+     *    *         /  \
+     *   / \       /    \
+     *  /   \     /      \ 
+     * u     q   u        q
+     *   One        Two
     */
     enum OpStruct {
         One=0,


### PR DESCRIPTION
Changes:
- Add custom timers
- Add `Parity` and `OpStruct` enums
- Add alias' for  `DMixingUtils<FImpl>::Parity`, `DMixingUtils<FImpl>::OpStruct`, `DMixingUtils<FImpl>::GHs`, and `DMixingUtils<FImpl>::parityG`
 I can't find a clean way to alias `DMixingUtils<FImpl>::GH_cap` so those are left as is
- Removed unnecessary namespace identification (e.g. `TDMixingTopD<FImpl>::PropagatorField` -> `PropagatorField`)